### PR TITLE
Small patch for spring-security-ui - issue with user accounts not being unlocked

### DIFF
--- a/grails-app/controllers/grails/plugins/springsecurity/ui/RegisterController.groovy
+++ b/grails-app/controllers/grails/plugins/springsecurity/ui/RegisterController.groovy
@@ -89,7 +89,7 @@ class RegisterController extends AbstractS2UiController {
 				return
 			}
 			user.accountLocked = false
-			user.save()
+			user.save(flush:true)
 			def UserRole = lookupUserRoleClass()
 			def Role = lookupRoleClass()
 			for (roleName in conf.ui.register.defaultRoleNames) {


### PR DESCRIPTION
Using default spring security ui plugin on 1.3.6 if you register and then click on confirmation email, it logs you in, but if you then log out and try to log in again it gives "account locked" message. Flushing the user.save() after the user.accountlocked=false seems to solve the problem.

Still getting my feet wet with Grails (been busy with lots of non-Grails projects :( ) so if this is just something I'm missing, please ignore and my apologies in advance.

Best Wishes,
Peter
