### PR TITLE
multiple encodings break the password

### DIFF
--- a/grails-app/controllers/grails/plugins/springsecurity/ui/UserController.groovy
+++ b/grails-app/controllers/grails/plugins/springsecurity/ui/UserController.groovy
@@ -37,8 +37,7 @@ class UserController extends AbstractS2UiController {
 	def save = {
 		def user = lookupUserClass().newInstance(params)
 		if (params.password) {
-			String salt = saltSource instanceof NullSaltSource ? null : params.username
-			user.password = springSecurityUiService.encodePassword(params.password, salt)
+			user.password = params.password
 		}
 		if (!user.save(flush: true)) {
 			render view: 'create', model: [user: user, authorityList: sortedRoles()]
@@ -72,8 +71,7 @@ class UserController extends AbstractS2UiController {
 		def oldPassword = user."$passwordFieldName"
 		user.properties = params
 		if (params.password && !params.password.equals(oldPassword)) {
-			String salt = saltSource instanceof NullSaltSource ? null : params.username
-			user."$passwordFieldName" = springSecurityUiService.encodePassword(params.password, salt)
+			user."$passwordFieldName" = params.password
 		}
 
 		if (!user.save(flush: true)) {

--- a/grails-app/services/grails/plugins/springsecurity/ui/SpringSecurityUiService.groovy
+++ b/grails-app/services/grails/plugins/springsecurity/ui/SpringSecurityUiService.groovy
@@ -180,8 +180,7 @@ class SpringSecurityUiService {
 		String usernameFieldName = SpringSecurityUtils.securityConfig.userLookup.usernamePropertyName
 		String passwordFieldName = SpringSecurityUtils.securityConfig.userLookup.passwordPropertyName
 
-		String password = encodePassword(cleartextPassword, salt)
-		user."$passwordFieldName" = password
+		user."$passwordFieldName" = cleartextPassword
 		if (!user.save()) {
 			warnErrors user, messageSource
 			TransactionAspectSupport.currentTransactionStatus().setRollbackOnly()


### PR DESCRIPTION
an encode() method call in it - the password gets encode()d·
twice, and one can never log in with one's password.

Maybe this should stay in these files, and the encode()ing in the·
User domain should be removed.  These files have 'salt'
mechanisms in them, which is missing from the user domain,
although that could be added there perhaps?

In any event, I have to modify these files to get basic
self registration and subseqent password authentication to work.
