### PR TITLE
Unnecessary logic double-checks whether user has roles, creates extra ma...

### DIFF
--- a/grails-app/controllers/grails/plugins/springsecurity/ui/UserController.groovy
+++ b/grails-app/controllers/grails/plugins/springsecurity/ui/UserController.groovy
@@ -218,19 +218,13 @@ class UserController extends AbstractS2UiController {
 
 		List roles = sortedRoles()
 		Set userRoleNames = user[authoritiesPropertyName].collect { it[authorityFieldName] }
-		def granted = [:]
-		def notGranted = [:]
+		def roleMap = [:] as LinkedHashMap
 		for (role in roles) {
 			String authority = role[authorityFieldName]
-			if (userRoleNames.contains(authority)) {
-				granted[(role)] = userRoleNames.contains(authority)
-			}
-			else {
-				notGranted[(role)] = userRoleNames.contains(authority)
-			}
+			roleMap[(role)] = userRoleNames.contains(authority)
 		}
 
-		return [user: user, roleMap: granted + notGranted]
+		return [user: user, roleMap: roleMap]
 	}
 
 	protected findById() {


### PR DESCRIPTION
...p object, loses order. Changed to use a single LinkedHashMap to preserve order, simplified logic to only do the 'contains' check one time for each role.
