### PR TITLE
Lookup username property for dynamic finder methods.

### DIFF
--- a/grails-app/controllers/grails/plugins/springsecurity/ui/RegisterController.groovy
+++ b/grails-app/controllers/grails/plugins/springsecurity/ui/RegisterController.groovy
@@ -187,8 +187,6 @@ class RegisterController extends AbstractS2UiController {
 		}
 
 		String salt = saltSource instanceof NullSaltSource ? null : registrationCode.username
-		
-		
 		RegistrationCode.withTransaction { status ->
 			String usernameFieldName = SpringSecurityUtils.securityConfig.userLookup.usernamePropertyName
 			def user = lookupUserClass().findWhere((usernameFieldName): registrationCode.username)


### PR DESCRIPTION
Use Spring Security Util to lookup the username property passed to
dynamic finders. Allows for User objects without a 'username' field to
use the plugin without modification.
