### PR TITLE
Fixes requestmap menu entry problem

### DIFF
--- a/grails-app/views/layouts/springSecurityUI.gsp
+++ b/grails-app/views/layouts/springSecurityUI.gsp
@@ -86,7 +86,7 @@ the explicit tags above and edit those, not the taglib code.
 						<li><g:link controller="role" action='create'><g:message code="spring.security.ui.create"/></g:link></li>
 					</ul>
 				</li>
-				<g:if test='${SpringSecurityUtils.securityConfig.securityConfigType == SecurityConfigType.Requestmap}'>
+				<g:if test='${SpringSecurityUtils.securityConfig.securityConfigType?.toString() == SecurityConfigType.Requestmap.toString()}'>
 				<li><a class="accessible"><g:message code="spring.security.ui.menu.requestmaps"/></a>
 					<ul>
 						<li><g:link controller="requestmap" action='search'><g:message code="spring.security.ui.search"/></g:link></li>


### PR DESCRIPTION
- when using s2-quickstart the entry in Config.groovy is a String which is compared to a enum in springSecurityUI.gsp -> false
- best bet is to use toString() on both sites as we don't know if an Enum or a String is used in Config.groovy (name() would be an option for the enum)
