### PR TITLE
Fix for deprecated classes in Grails 2.0+

### DIFF
--- a/grails-app/taglib/grails/plugin/springsecurity/ui/SecurityUiTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/springsecurity/ui/SecurityUiTagLib.groovy
@@ -14,7 +14,7 @@
  */
 package grails.plugin.springsecurity.ui
 
-import org.codehaus.groovy.grails.plugins.PluginManagerHolder
+import grails.util.Holders
 
 /**
  * @author <a href='mailto:burt@burtbeckwith.com'>Burt Beckwith</a>
@@ -24,7 +24,7 @@ class SecurityUiTagLib {
 	static namespace = 's2ui'
 
 	def resources = { attrs ->
-		boolean hasResourcesPlugin = PluginManagerHolder.pluginManager.hasGrailsPlugin('resources')
+		boolean hasResourcesPlugin = Holders.pluginManager.hasGrailsPlugin('resources')
 
 		if ('spring-security-ui' == attrs.module) {
 			if (hasResourcesPlugin) {
@@ -72,7 +72,7 @@ class SecurityUiTagLib {
 	}
 
 	def layoutResources = { attrs ->
-		boolean hasResourcesPlugin = PluginManagerHolder.pluginManager.hasGrailsPlugin('resources')
+		boolean hasResourcesPlugin = Holders.pluginManager.hasGrailsPlugin('resources')
 
 		if ('spring-security-ui' == attrs.module) {
 			if (hasResourcesPlugin) {

--- a/grails-app/views/layouts/springSecurityUI.gsp
+++ b/grails-app/views/layouts/springSecurityUI.gsp
@@ -1,4 +1,4 @@
-<%@ page import="org.codehaus.groovy.grails.plugins.PluginManagerHolder" %>
+<%@ page import="grails.util.Holders" %>
 <%@ page import="grails.plugin.springsecurity.SpringSecurityUtils" %>
 
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
@@ -105,7 +105,7 @@ the explicit tags above and edit those, not the taglib code.
 						<li><g:link controller="registrationCode" action='search'><g:message code="spring.security.ui.search"/></g:link></li>
 					</ul>
 				</li>
-				<g:if test="${PluginManagerHolder.pluginManager.hasGrailsPlugin('springSecurityAcl')}">
+				<g:if test="${Holders.pluginManager.hasGrailsPlugin('springSecurityAcl')}">
 				<li><a class="accessible"><g:message code="spring.security.ui.menu.acl"/></a>
 					<ul>
 						<li><g:message code="spring.security.ui.menu.aclClass"/> &raquo;

--- a/grails-app/views/user/edit.gsp
+++ b/grails-app/views/user/edit.gsp
@@ -1,5 +1,5 @@
 <html>
-<%@ page import="org.codehaus.groovy.grails.plugins.PluginManagerHolder" %>
+<%@ page import="grails.util.Holders" %>
 
 <sec:ifNotSwitched>
 	<sec:ifAllGranted roles='ROLE_SWITCH_USER'>
@@ -27,7 +27,7 @@
 def tabData = []
 tabData << [name: 'userinfo', icon: 'icon_user', messageCode: 'spring.security.ui.user.info']
 tabData << [name: 'roles',    icon: 'icon_role', messageCode: 'spring.security.ui.user.roles']
-boolean isOpenId = PluginManagerHolder.pluginManager.hasGrailsPlugin('springSecurityOpenid')
+boolean isOpenId = Holders.pluginManager.hasGrailsPlugin('springSecurityOpenid')
 if (isOpenId) {
 	tabData << [name: 'openIds', icon: 'icon_role', messageCode: 'spring.security.ui.user.openIds']
 }


### PR DESCRIPTION
Grails 2.4.0 removes org.codehaus.groovy.grails.plugins.PluginManagerHolder. Changing the classes to use grails.util.Holders works.
