### PR TITLE
Add missing username nullable message for RegisterCommand.

### DIFF
--- a/grails-app/i18n/messages.spring-security-ui.properties
+++ b/grails-app/i18n/messages.spring-security-ui.properties
@@ -79,6 +79,7 @@ command.password.error.username Password cannot be the same as the username
 command.password.error.strength Password must have at least one letter, number, and special character: \!@\#$%^&
 command.password2.error.mismatch Passwords do not match
 
+registerCommand.username.nullable Username is required
 registerCommand.username.blank Username is required
 registerCommand.username.unique The username is taken
 registerCommand.email.blank Email is required


### PR DESCRIPTION
When creating an account from the `register/index` view, if a blank form is submitted, all fields display correct error messages except for username (shown below):

![screenshot from 2014-11-28 08 29 48](https://cloud.githubusercontent.com/assets/3237612/5228533/5d69d5d2-76d9-11e4-88e0-0de1100bdc48.png)

This commit resolves this issue.