### PR TITLE
Remove instance identifier from s2uiBeanType

### DIFF
--- a/grails-app/taglib/grails/plugin/springsecurity/ui/SecurityUiTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/springsecurity/ui/SecurityUiTagLib.groovy
@@ -190,7 +190,8 @@ class SecurityUiTagLib {
 		def bean
 		String beanName = attrs.remove('beanName')
 		if (beanName) {
-			bean = pageScope.s2uiBean = pageScope.s2uiBeanType = pageScope[beanName]
+			bean = pageScope.s2uiBean = pageScope[beanName]
+			pageScope.s2uiBeanType = bean.getClass().name
 			assert bean
 		}
 		else {


### PR DESCRIPTION
It isn't currently possible to configure custom labels when using the s2ui tags without setting an explicit labelCode because the default labelCode includes an instance identifier.

Default labelCodes currently end up looking something like `grails.plugin.springsecurity.ui.RegisterCommand@1cfae57.email.label`.

The easy workaround is to just explicitly set the labelCode when using one of the tags that relies on them.
