### PR TITLE
s2uiBeanType should be the type, not the bean itself

### DIFF
--- a/grails-app/taglib/grails/plugin/springsecurity/ui/SecurityUiTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/springsecurity/ui/SecurityUiTagLib.groovy
@@ -190,7 +190,8 @@ class SecurityUiTagLib {
 		def bean
 		String beanName = attrs.remove('beanName')
 		if (beanName) {
-			bean = pageScope.s2uiBean = pageScope.s2uiBeanType = pageScope[beanName]
+			pageScope.s2uiBeanType = beanName
+			bean = pageScope.s2uiBean = pageScope[beanName]
 			assert bean
 		}
 		else {


### PR DESCRIPTION
fixes #56, #51

Otherwise the bean will be cast to string in `labelCode`,
which will throw an assertion error if the bean returns null
in its "toString" method.

Also, I cannot see why somebody would want to use the `toString`
of e.g. a user object to look up the localization of the label
of that field. That just does not make sense.

user.username.label resp. role.authority.label is way more intuitive..
