### PR TITLE
Fixes forgotPassword config in RegisterController

### DIFF
--- a/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
+++ b/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
@@ -209,7 +209,7 @@ class RegisterController extends AbstractS2UiController {
 		registerEmailFrom = conf.ui.register.emailFrom ?: ''
 		registerEmailSubject = conf.ui.register.emailSubject ?: ''
 		registerPostRegisterUrl = conf.ui.register.postRegisterUrl ?: ''
-		registerPostResetUrl = conf.ui.register.postResetUrl ?: ''
+		registerPostResetUrl = conf.ui.forgotPassword.postResetUrl ?: ''
 		successHandlerDefaultTargetUrl = conf.successHandler.defaultTargetUrl ?: '/'
 
 		passwordMaxLength = conf.ui.password.maxLength instanceof Number ? conf.ui.password.maxLength : 64


### PR DESCRIPTION
Hi @burtbeckwith 

This is fix for https://github.com/grails-plugins/grails-spring-security-ui/issues/60

In `RegisterController` the `registerPostResetUrl` variable looks for `conf.ui.register.postResetUrl` which should be `conf.ui.forgotPassword.postResetUrl`.
