### PR TITLE
SpringSecurityUiService.getProperty returns nil preventing password reset

### DIFF
--- a/grails-app/services/grails/plugin/springsecurity/ui/SpringSecurityUiService.groovy
+++ b/grails-app/services/grails/plugin/springsecurity/ui/SpringSecurityUiService.groovy
@@ -407,7 +407,7 @@ class SpringSecurityUiService implements AclStrategy, ErrorsStrategy, Persistent
 
 			try {
 				if (instance.metaClass.getMetaProperty(propertyName)?.getter) {
-					value = value[propertyName]
+					value = value."${propertyName}"
 					if (value == null) return
 				}
 				else {


### PR DESCRIPTION
Not sure if this is the best fix, however, in my case I was receiving "We have no email registered for your account" when trying to reset a password, because although the user was found, and userDomain.email would return a result, the way it is retrieved in helper method using *instance[propertyName]* returns nil. Using my debugger, I tracked it down to line 410 in SpringSecurityUiService.groovy.  There you will find that:

```

value."${propertyName}" // returns "email@address.com" as well as value.email 
value[propertyName] // returns nil
```

It should be noted also, that my Domain with the email property is a subclass of base User model which does not have an email, and that I'm using grails 3.2.9 . Thanks for the great work, hope this helps somehow!