### PR TITLE
Issue-60: postResetUrl not working

### DIFF
--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
@@ -209,7 +209,7 @@ class RegisterController extends AbstractS2UiController {
 		registerEmailFrom = conf.ui.register.emailFrom ?: ''
 		registerEmailSubject = conf.ui.register.emailSubject ?: ''
 		registerPostRegisterUrl = conf.ui.register.postRegisterUrl ?: ''
-		registerPostResetUrl = conf.ui.register.postResetUrl ?: ''
+		registerPostResetUrl = conf.ui.forgotPassword.postResetUrl ?: ''
 		successHandlerDefaultTargetUrl = conf.successHandler.defaultTargetUrl ?: '/'
 
 		passwordMaxLength = conf.ui.password.maxLength instanceof Number ? conf.ui.password.maxLength : 64


### PR DESCRIPTION
Documentation suggests to use `grails.plugin.springsecurity.ui.forgotPassword.postResetUrl` in order to set the URL after a password reset. For example:

```
grails.plugin.springsecurity.ui.forgotPassword.postResetUrl = '/reset'
```

In `RegisterController` the `registerPostResetUrl` variable looks for `conf.ui.register.postResetUrl `which should be `conf.ui.forgotPassword.postResetUrl`.

https://github.com/grails-plugins/grails-spring-security-ui/blob/master/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy#L212

Updated `RegisterController.registerPostResetUrl` to be:

```
registerPostResetUrl = conf.ui.forgotPassword.postResetUrl ?: ''
```