### PR TITLE
Issue #56: Error with Grails Spring Security UI Plugin when creating new user - Error Processing GroovyPageView

### DIFF
--- a/plugin/grails-app/taglib/grails/plugin/springsecurity/ui/SecurityUiTagLib.groovy
+++ b/plugin/grails-app/taglib/grails/plugin/springsecurity/ui/SecurityUiTagLib.groovy
@@ -190,7 +190,8 @@ class SecurityUiTagLib {
 		def bean
 		String beanName = attrs.remove('beanName')
 		if (beanName) {
-			bean = pageScope.s2uiBean = pageScope.s2uiBeanType = pageScope[beanName]
+			pageScope.s2uiBeanType = beanName
+			bean = pageScope.s2uiBean = pageScope[beanName]
 			assert bean
 		}
 		else {


### PR DESCRIPTION
Modified `form` tag so that
• `pageScope.s2uiBeanType` consistently set to the bean name

Fixes Issue #56

Duplicates changes provided by PRs [42](https://github.com/grails-plugins/grails-spring-security-ui/pull/42/files) and [57](https://github.com/grails-plugins/grails-spring-security-ui/pull/57/files)

Those PRs ☝️  were old and had conflicts.