### PR TITLE
Issue #9: All pages vulnerable to CSRF

### DIFF
--- a/docs/src/docs/introduction.adoc
+++ b/docs/src/docs/introduction.adoc
@@ -1,7 +1,11 @@
 [[introduction]]
 == Introduction to the Spring Security UI Plugin
 
-The Spring Security UI plugin provides CRUD screens and other user management workflows. Non-default functionality is available only if the feature is available; this includes the ACL controllers and views which are enabled if the http://grails.org/plugin/spring-security-acl[ACL plugin] is installed, Requestmaps support which is available if `grails.plugin.springsecurity.securityConfigType` is set to `"Requestmap"` or `SecurityConfigType.Requestmap` in `application.groovy`, and persistent cookies support which is enabled if it has been configured with the `s2-create-persistent-token` script.
+The Spring Security UI plugin provides CRUD screens and other user management workflows.
+
+The CRUD screens are protected from cross-site request forgery (CSRF) attacks through the use of the `useToken` attribute in forms. More information is available at http://docs.grails.org/latest/guide/theWebLayer.html#formtokens.
+
+Non-default functionality is available only if the feature is available; this includes the ACL controllers and views which are enabled if the http://grails.org/plugin/spring-security-acl[ACL plugin] is installed, Requestmaps support which is available if `grails.plugin.springsecurity.securityConfigType` is set to `"Requestmap"` or `SecurityConfigType.Requestmap` in `application.groovy`, and persistent cookies support which is enabled if it has been configured with the `s2-create-persistent-token` script.
 
 
 === Installation

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AbstractS2UiDomainController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AbstractS2UiDomainController.groovy
@@ -15,6 +15,7 @@
 package grails.plugin.springsecurity.ui
 
 import grails.converters.JSON
+import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.ui.strategy.AclStrategy
 import grails.plugin.springsecurity.ui.strategy.PropertiesStrategy
 import grails.plugin.springsecurity.ui.strategy.QueryStrategy
@@ -62,6 +63,16 @@ abstract class AbstractS2UiDomainController extends AbstractS2UiController {
 		redirectToEdit instance.id
 	}
 
+	protected doSaveWithInvalidToken(String flashArg = "") {
+		if (!flashArg) {
+			flashArg = "${message(code: 'spring.security.ui.invalid.form.default.arg')}"
+		}
+		response.status = 500
+		log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+		flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [flashArg])}"
+		redirect action: 'create'
+	}
+
 	protected void renderCreate(Map model) {
 		render view: 'create', model: model
 	}
@@ -94,6 +105,16 @@ abstract class AbstractS2UiDomainController extends AbstractS2UiController {
 		}
 	}
 
+	protected doUpdateWithInvalidToken(String flashArg = "") {
+		if (!flashArg) {
+			flashArg = "${message(code: 'spring.security.ui.invalid.form.default.arg')}"
+		}
+		response.status = 500
+		log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+		flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [flashArg])}"
+		redirectToSearch()
+	}
+
 	protected void renderEdit(Map model) {
 		render view: 'edit', model: model
 	}
@@ -111,6 +132,16 @@ abstract class AbstractS2UiDomainController extends AbstractS2UiController {
 			flashNotDeleted()
 			redirectToEdit()
 		}
+	}
+
+	protected doDeleteWithInvalidToken(String flashArg = "") {
+		if (!flashArg) {
+			flashArg = "${message(code: 'spring.security.ui.invalid.form.default.arg')}"
+		}
+		response.status = 500
+		log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+		flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [flashArg])}"
+		redirectToSearch()
 	}
 
 	protected abstract search()

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AbstractS2UiDomainController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AbstractS2UiDomainController.groovy
@@ -68,7 +68,7 @@ abstract class AbstractS2UiDomainController extends AbstractS2UiController {
 			flashArg = "${message(code: 'spring.security.ui.invalid.form.default.arg')}"
 		}
 		response.status = 500
-		log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+		log.warn('User: {} possible CSRF or double submit: {}', SpringSecurityUtils.authentication.principal.id as String, params as String)
 		flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [flashArg])}"
 		redirect action: 'create'
 	}
@@ -110,7 +110,7 @@ abstract class AbstractS2UiDomainController extends AbstractS2UiController {
 			flashArg = "${message(code: 'spring.security.ui.invalid.form.default.arg')}"
 		}
 		response.status = 500
-		log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+		log.warn('User: {} possible CSRF or double submit: {}', SpringSecurityUtils.authentication.principal.id as String, params as String)
 		flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [flashArg])}"
 		redirectToSearch()
 	}
@@ -139,7 +139,7 @@ abstract class AbstractS2UiDomainController extends AbstractS2UiController {
 			flashArg = "${message(code: 'spring.security.ui.invalid.form.default.arg')}"
 		}
 		response.status = 500
-		log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+		log.warn('User: {} possible CSRF or double submit: {}', SpringSecurityUtils.authentication.principal.id as String, params as String)
 		flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [flashArg])}"
 		redirectToSearch()
 	}

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclClassController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclClassController.groovy
@@ -14,6 +14,8 @@
  */
 package grails.plugin.springsecurity.ui
 
+import grails.plugin.springsecurity.SpringSecurityUtils
+
 /**
  * @author <a href='mailto:burt@burtbeckwith.com'>Burt Beckwith</a>
  */
@@ -24,7 +26,15 @@ class AclClassController extends AbstractS2UiDomainController {
 	}
 
 	def save() {
-		doSave uiAclStrategy.saveAclClass(params)
+		withForm {
+			doSave uiAclStrategy.saveAclClass(params)
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [params.username])}"
+			redirect(action: "create")
+			return
+		}
 	}
 
 	def edit() {
@@ -32,14 +42,29 @@ class AclClassController extends AbstractS2UiDomainController {
 	}
 
 	def update() {
-		doUpdate { aclClass ->
-			uiAclStrategy.updateAclClass params, aclClass
+		withForm {
+			doUpdate { aclClass ->
+				uiAclStrategy.updateAclClass params, aclClass
+			}
+		} {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
+			redirectToSearch()
+			return
 		}
 	}
 
 	def delete() {
-		tryDelete { aclClass ->
-			uiAclStrategy.deleteAclClass aclClass
+		withForm {
+			tryDelete { aclClass ->
+				uiAclStrategy.deleteAclClass aclClass
+			}
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
+			redirectToSearch()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclClassController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclClassController.groovy
@@ -29,11 +29,7 @@ class AclClassController extends AbstractS2UiDomainController {
 		withForm {
 			doSave uiAclStrategy.saveAclClass(params)
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [params.username])}"
-			redirect(action: "create")
-			return
+			doSaveWithInvalidToken(params.username)
 		}
 	}
 
@@ -46,12 +42,8 @@ class AclClassController extends AbstractS2UiDomainController {
 			doUpdate { aclClass ->
 				uiAclStrategy.updateAclClass params, aclClass
 			}
-		} {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
-			redirectToSearch()
-			return
+		}.invalidToken {
+			doUpdateWithInvalidToken(params.username)
 		}
 	}
 
@@ -61,10 +53,7 @@ class AclClassController extends AbstractS2UiDomainController {
 				uiAclStrategy.deleteAclClass aclClass
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
-			redirectToSearch()
+			doDeleteWithInvalidToken()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclClassController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclClassController.groovy
@@ -14,8 +14,6 @@
  */
 package grails.plugin.springsecurity.ui
 
-import grails.plugin.springsecurity.SpringSecurityUtils
-
 /**
  * @author <a href='mailto:burt@burtbeckwith.com'>Burt Beckwith</a>
  */

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclEntryController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclEntryController.groovy
@@ -32,11 +32,7 @@ class AclEntryController extends AbstractS2UiDomainController {
 		withForm {
 			doSave uiAclStrategy.saveAclEntry(params)
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [params.username])}"
-			redirect(action: "create")
-			return
+			doSaveWithInvalidToken(params.username)
 		}
 	}
 
@@ -50,11 +46,7 @@ class AclEntryController extends AbstractS2UiDomainController {
 				uiAclStrategy.updateAclEntry params, aclEntry
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
-			redirectToSearch()
-			return
+			doUpdateWithInvalidToken(params.username)
 		}
 	}
 
@@ -64,10 +56,7 @@ class AclEntryController extends AbstractS2UiDomainController {
 				uiAclStrategy.deleteAclEntry aclEntry
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
-			redirectToSearch()
+			doDeleteWithInvalidToken()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclEntryController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclEntryController.groovy
@@ -14,8 +14,6 @@
  */
 package grails.plugin.springsecurity.ui
 
-import grails.plugin.springsecurity.SpringSecurityUtils
-
 /**
  * @author <a href='mailto:burt@burtbeckwith.com'>Burt Beckwith</a>
  */

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclObjectIdentityController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclObjectIdentityController.groovy
@@ -14,6 +14,8 @@
  */
 package grails.plugin.springsecurity.ui
 
+import grails.plugin.springsecurity.SpringSecurityUtils
+
 /**
  * @author <a href='mailto:burt@burtbeckwith.com'>Burt Beckwith</a>
  */
@@ -24,7 +26,15 @@ class AclObjectIdentityController extends AbstractS2UiDomainController {
 	}
 
 	def save() {
-		doSave uiAclStrategy.saveAclObjectIdentity(params)
+		withForm {
+			doSave uiAclStrategy.saveAclObjectIdentity(params)
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [params.username])}"
+			redirect(action: "create")
+			return
+		}
 	}
 
 	def edit() {
@@ -32,14 +42,29 @@ class AclObjectIdentityController extends AbstractS2UiDomainController {
 	}
 
 	def update() {
-		doUpdate { aclObjectIdentity ->
-			uiAclStrategy.updateAclObjectIdentity params, aclObjectIdentity
+		withForm {
+			doUpdate { aclObjectIdentity ->
+				uiAclStrategy.updateAclObjectIdentity params, aclObjectIdentity
+			}
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
+			redirectToSearch()
+			return
 		}
 	}
 
 	def delete() {
-		tryDelete { aclObjectIdentity ->
-			uiAclStrategy.deleteAclObjectIdentity aclObjectIdentity
+		withForm {
+			tryDelete { aclObjectIdentity ->
+				uiAclStrategy.deleteAclObjectIdentity aclObjectIdentity
+			}
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
+			redirectToSearch()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclObjectIdentityController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclObjectIdentityController.groovy
@@ -29,11 +29,7 @@ class AclObjectIdentityController extends AbstractS2UiDomainController {
 		withForm {
 			doSave uiAclStrategy.saveAclObjectIdentity(params)
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [params.username])}"
-			redirect(action: "create")
-			return
+			doSaveWithInvalidToken(params.username)
 		}
 	}
 
@@ -47,11 +43,7 @@ class AclObjectIdentityController extends AbstractS2UiDomainController {
 				uiAclStrategy.updateAclObjectIdentity params, aclObjectIdentity
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
-			redirectToSearch()
-			return
+			doUpdateWithInvalidToken(params.username)
 		}
 	}
 
@@ -61,10 +53,7 @@ class AclObjectIdentityController extends AbstractS2UiDomainController {
 				uiAclStrategy.deleteAclObjectIdentity aclObjectIdentity
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
-			redirectToSearch()
+			doDeleteWithInvalidToken()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclObjectIdentityController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclObjectIdentityController.groovy
@@ -14,8 +14,6 @@
  */
 package grails.plugin.springsecurity.ui
 
-import grails.plugin.springsecurity.SpringSecurityUtils
-
 /**
  * @author <a href='mailto:burt@burtbeckwith.com'>Burt Beckwith</a>
  */

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclSidController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclSidController.groovy
@@ -29,11 +29,7 @@ class AclSidController extends AbstractS2UiDomainController {
 		withForm {
 			doSave uiAclStrategy.saveAclSid(params)
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [params.username])}"
-			redirect(action: "create")
-			return
+			doSaveWithInvalidToken(params.username)
 		}
 	}
 
@@ -47,11 +43,7 @@ class AclSidController extends AbstractS2UiDomainController {
 				uiAclStrategy.updateAclSid params, aclSid
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
-			redirectToSearch()
-			return
+			doUpdateWithInvalidToken(params.username)
 		}
 	}
 
@@ -61,10 +53,7 @@ class AclSidController extends AbstractS2UiDomainController {
 				uiAclStrategy.deleteAclSid aclSid
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
-			redirectToSearch()
+			doDeleteWithInvalidToken()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclSidController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclSidController.groovy
@@ -14,6 +14,8 @@
  */
 package grails.plugin.springsecurity.ui
 
+import grails.plugin.springsecurity.SpringSecurityUtils
+
 /**
  * @author <a href='mailto:burt@burtbeckwith.com'>Burt Beckwith</a>
  */
@@ -24,7 +26,15 @@ class AclSidController extends AbstractS2UiDomainController {
 	}
 
 	def save() {
-		doSave uiAclStrategy.saveAclSid(params)
+		withForm {
+			doSave uiAclStrategy.saveAclSid(params)
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [params.username])}"
+			redirect(action: "create")
+			return
+		}
 	}
 
 	def edit() {
@@ -32,14 +42,29 @@ class AclSidController extends AbstractS2UiDomainController {
 	}
 
 	def update() {
-		doUpdate { aclSid ->
-			uiAclStrategy.updateAclSid params, aclSid
+		withForm {
+			doUpdate { aclSid ->
+				uiAclStrategy.updateAclSid params, aclSid
+			}
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
+			redirectToSearch()
+			return
 		}
 	}
 
 	def delete() {
-		tryDelete { aclSid ->
-			uiAclStrategy.deleteAclSid aclSid
+		withForm {
+			tryDelete { aclSid ->
+				uiAclStrategy.deleteAclSid aclSid
+			}
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
+			redirectToSearch()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclSidController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/AclSidController.groovy
@@ -14,8 +14,6 @@
  */
 package grails.plugin.springsecurity.ui
 
-import grails.plugin.springsecurity.SpringSecurityUtils
-
 /**
  * @author <a href='mailto:burt@burtbeckwith.com'>Burt Beckwith</a>
  */

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/PersistentLoginController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/PersistentLoginController.groovy
@@ -35,11 +35,7 @@ class PersistentLoginController extends AbstractS2UiDomainController {
 				uiPersistentLoginStrategy.updatePersistentLogin params, persistentLogin
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
-			redirectToSearch()
-			return
+			doUpdateWithInvalidToken(params.username)
 		}
 	}
 
@@ -49,10 +45,7 @@ class PersistentLoginController extends AbstractS2UiDomainController {
 				uiPersistentLoginStrategy.deletePersistentLogin persistentLogin
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
-			redirectToSearch()
+			doDeleteWithInvalidToken()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/PersistentLoginController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/PersistentLoginController.groovy
@@ -14,6 +14,7 @@
  */
 package grails.plugin.springsecurity.ui
 
+import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.ui.strategy.PersistentLoginStrategy
 
 /**
@@ -29,14 +30,29 @@ class PersistentLoginController extends AbstractS2UiDomainController {
 	}
 
 	def update() {
-		doUpdate { persistentLogin ->
-			uiPersistentLoginStrategy.updatePersistentLogin params, persistentLogin
+		withForm {
+			doUpdate { persistentLogin ->
+				uiPersistentLoginStrategy.updatePersistentLogin params, persistentLogin
+			}
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
+			redirectToSearch()
+			return
 		}
 	}
 
 	def delete() {
-		tryDelete { persistentLogin ->
-			uiPersistentLoginStrategy.deletePersistentLogin persistentLogin
+		withForm {
+			tryDelete { persistentLogin ->
+				uiPersistentLoginStrategy.deletePersistentLogin persistentLogin
+			}
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
+			redirectToSearch()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/PersistentLoginController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/PersistentLoginController.groovy
@@ -14,7 +14,6 @@
  */
 package grails.plugin.springsecurity.ui
 
-import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.ui.strategy.PersistentLoginStrategy
 
 /**

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegistrationCodeController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegistrationCodeController.groovy
@@ -14,6 +14,7 @@
  */
 package grails.plugin.springsecurity.ui
 
+import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.ui.strategy.RegistrationCodeStrategy
 
 /**
@@ -29,14 +30,29 @@ class RegistrationCodeController extends AbstractS2UiDomainController {
 	}
 
 	def update() {
-		doUpdate { registrationCode ->
-			uiRegistrationCodeStrategy.updateRegistrationCode params, registrationCode
+		withForm {
+			doUpdate { registrationCode ->
+				uiRegistrationCodeStrategy.updateRegistrationCode params, registrationCode
+			}
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
+			redirectToSearch()
+			return
 		}
 	}
 
 	def delete() {
-		tryDelete { registrationCode ->
-			uiRegistrationCodeStrategy.deleteRegistrationCode registrationCode
+		withForm {
+			tryDelete { registrationCode ->
+				uiRegistrationCodeStrategy.deleteRegistrationCode registrationCode
+			}
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
+			redirectToSearch()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegistrationCodeController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegistrationCodeController.groovy
@@ -35,11 +35,7 @@ class RegistrationCodeController extends AbstractS2UiDomainController {
 				uiRegistrationCodeStrategy.updateRegistrationCode params, registrationCode
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
-			redirectToSearch()
-			return
+			doUpdateWithInvalidToken(params.username)
 		}
 	}
 
@@ -49,10 +45,7 @@ class RegistrationCodeController extends AbstractS2UiDomainController {
 				uiRegistrationCodeStrategy.deleteRegistrationCode registrationCode
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
-			redirectToSearch()
+			doDeleteWithInvalidToken()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegistrationCodeController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegistrationCodeController.groovy
@@ -14,7 +14,6 @@
  */
 package grails.plugin.springsecurity.ui
 
-import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.ui.strategy.RegistrationCodeStrategy
 
 /**
@@ -35,7 +34,7 @@ class RegistrationCodeController extends AbstractS2UiDomainController {
 				uiRegistrationCodeStrategy.updateRegistrationCode params, registrationCode
 			}
 		}.invalidToken {
-			doUpdateWithInvalidToken(params.username)
+			doUpdateWithInvalidToken()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RequestmapController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RequestmapController.groovy
@@ -35,10 +35,11 @@ class RequestmapController extends AbstractS2UiDomainController {
 
 	def save() {
 		withForm {
-			if (!(param('url'))) params.remove('url') {
-				doSave(uiRequestmapStrategy.saveRequestmap(params)) {
-					springSecurityService.clearCachedRequestmaps()
-				}
+			if (!(param('url'))) {
+				params.remove('url')
+			}
+			doSave(uiRequestmapStrategy.saveRequestmap(params)) {
+				springSecurityService.clearCachedRequestmaps()
 			}
 		}.invalidToken {
 			response.status = 500
@@ -55,10 +56,11 @@ class RequestmapController extends AbstractS2UiDomainController {
 
 	def update() {
 		withForm {
-			if (!(param('url'))) params.remove('url') {
-				doUpdate { requestmap ->
-					uiRequestmapStrategy.updateRequestmap params, requestmap
-				}
+			if (!(param('url'))) {
+				params.remove('url')
+			}
+			doUpdate { requestmap ->
+				uiRequestmapStrategy.updateRequestmap params, requestmap
 			}
 		}.invalidToken {
 			response.status = 500

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RequestmapController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RequestmapController.groovy
@@ -42,11 +42,7 @@ class RequestmapController extends AbstractS2UiDomainController {
 				springSecurityService.clearCachedRequestmaps()
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [params.username])}"
-			redirect(action: "create")
-			return
+			doSaveWithInvalidToken(params.username)
 		}
 	}
 
@@ -63,11 +59,7 @@ class RequestmapController extends AbstractS2UiDomainController {
 				uiRequestmapStrategy.updateRequestmap params, requestmap
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
-			redirectToSearch()
-			return
+			doUpdateWithInvalidToken(params.username)
 		}
 	}
 
@@ -77,10 +69,7 @@ class RequestmapController extends AbstractS2UiDomainController {
 				uiRequestmapStrategy.deleteRequestmap requestmap
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
-			redirectToSearch()
+			doDeleteWithInvalidToken()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RequestmapController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RequestmapController.groovy
@@ -15,7 +15,6 @@
 package grails.plugin.springsecurity.ui
 
 import grails.plugin.springsecurity.ReflectionUtils
-import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.ui.strategy.RequestmapStrategy
 import org.springframework.http.HttpMethod
 
@@ -42,7 +41,7 @@ class RequestmapController extends AbstractS2UiDomainController {
 				springSecurityService.clearCachedRequestmaps()
 			}
 		}.invalidToken {
-			doSaveWithInvalidToken(params.username)
+			doSaveWithInvalidToken(params.url)
 		}
 	}
 
@@ -59,7 +58,7 @@ class RequestmapController extends AbstractS2UiDomainController {
 				uiRequestmapStrategy.updateRequestmap params, requestmap
 			}
 		}.invalidToken {
-			doUpdateWithInvalidToken(params.username)
+			doUpdateWithInvalidToken(params.url)
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RoleController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RoleController.groovy
@@ -14,7 +14,6 @@
  */
 package grails.plugin.springsecurity.ui
 
-import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.ui.strategy.RoleStrategy
 import grails.util.GrailsNameUtils
 
@@ -34,7 +33,7 @@ class RoleController extends AbstractS2UiDomainController {
 		withForm {
 			doSave uiRoleStrategy.saveRole(params)
 		}.invalidToken {
-			doSaveWithInvalidToken(params.username)
+			doSaveWithInvalidToken(params.authority)
 		}
 	}
 
@@ -48,7 +47,7 @@ class RoleController extends AbstractS2UiDomainController {
 				uiRoleStrategy.updateRole params, role
 			}
 		}.invalidToken {
-			doUpdateWithInvalidToken(params.username)
+			doUpdateWithInvalidToken(params.authority)
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RoleController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RoleController.groovy
@@ -34,11 +34,7 @@ class RoleController extends AbstractS2UiDomainController {
 		withForm {
 			doSave uiRoleStrategy.saveRole(params)
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [params.username])}"
-			redirect(action: "create")
-			return
+			doSaveWithInvalidToken(params.username)
 		}
 	}
 
@@ -52,11 +48,7 @@ class RoleController extends AbstractS2UiDomainController {
 				uiRoleStrategy.updateRole params, role
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
-			redirectToSearch()
-			return
+			doUpdateWithInvalidToken(params.username)
 		}
 	}
 
@@ -66,10 +58,7 @@ class RoleController extends AbstractS2UiDomainController {
 				uiRoleStrategy.deleteRole role
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
-			redirectToSearch()
+			doDeleteWithInvalidToken()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/UserController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/UserController.groovy
@@ -29,7 +29,15 @@ class UserController extends AbstractS2UiDomainController {
 	}
 
 	def save() {
-		doSave uiUserStrategy.saveUser(params, roleNamesFromParams(), params.password)
+		withForm {
+			doSave uiUserStrategy.saveUser(params, roleNamesFromParams(), params.password)
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${springSecurityService.currentUser.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [params.className])}"
+			redirect action: create
+			return
+		}
 	}
 
 	def edit() {

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/UserController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/UserController.groovy
@@ -14,6 +14,7 @@
  */
 package grails.plugin.springsecurity.ui
 
+import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.ui.strategy.UserStrategy
 
 /**
@@ -33,9 +34,9 @@ class UserController extends AbstractS2UiDomainController {
 			doSave uiUserStrategy.saveUser(params, roleNamesFromParams(), params.password)
 		}.invalidToken {
 			response.status = 500
-			log.warn("User: ${springSecurityService.currentUser.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [params.className])}"
-			redirect action: create
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [params.username])}"
+			redirect(action: "create")
 			return
 		}
 	}
@@ -45,14 +46,29 @@ class UserController extends AbstractS2UiDomainController {
 	}
 
 	def update() {
-		doUpdate { user ->
-			uiUserStrategy.updateUser params, user, roleNamesFromParams()
+		withForm {
+			doUpdate { user ->
+				uiUserStrategy.updateUser params, user, roleNamesFromParams()
+			}
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
+			redirectToSearch()
+			return
 		}
 	}
 
 	def delete() {
-		tryDelete { user ->
-			uiUserStrategy.deleteUser user
+		withForm{
+			tryDelete { user ->
+				uiUserStrategy.deleteUser user
+			}
+		}.invalidToken {
+			response.status = 500
+			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
+			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
+			redirectToSearch()
 		}
 	}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/UserController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/UserController.groovy
@@ -14,7 +14,6 @@
  */
 package grails.plugin.springsecurity.ui
 
-import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.ui.strategy.UserStrategy
 
 /**
@@ -33,11 +32,7 @@ class UserController extends AbstractS2UiDomainController {
 		withForm {
 			doSave uiUserStrategy.saveUser(params, roleNamesFromParams(), params.password)
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.save.form', args: [params.username])}"
-			redirect(action: "create")
-			return
+			doSaveWithInvalidToken(params.username)
 		}
 	}
 
@@ -51,11 +46,7 @@ class UserController extends AbstractS2UiDomainController {
 				uiUserStrategy.updateUser params, user, roleNamesFromParams()
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.update.form', args: [params.username])}"
-			redirectToSearch()
-			return
+			doUpdateWithInvalidToken(params.username)
 		}
 	}
 
@@ -65,10 +56,7 @@ class UserController extends AbstractS2UiDomainController {
 				uiUserStrategy.deleteUser user
 			}
 		}.invalidToken {
-			response.status = 500
-			log.warn("User: ${SpringSecurityUtils.authentication.principal.id} possible CSRF or double submit: $params")
-			flash.message = "${message(code: 'spring.security.ui.invalid.delete.form', args: [params.username])}"
-			redirectToSearch()
+			doDeleteWithInvalidToken()
 		}
 	}
 

--- a/plugin/grails-app/i18n/messages.spring-security-ui.properties
+++ b/plugin/grails-app/i18n/messages.spring-security-ui.properties
@@ -153,6 +153,7 @@ resetPasswordCommand.password.minSize.notmet Password must be between 8 and 64 c
 
 forgotPasswordCommand.username.nullable Please enter your username
 
+spring.security.ui.invalid.form.default.arg Oops! That
 spring.security.ui.invalid.save.form {0} may not have been created. Either the form was submitted twice or possible CSRF attempt. Be careful what you click.
 spring.security.ui.invalid.update.form {0} may not have been updated. Either the form was submitted twice or possible CSRF attempt. Be careful what you click.
 spring.security.ui.invalid.delete.form {0} may not have been deleted. Either the form was submitted twice or possible CSRF attempt. Be careful what you click.

--- a/plugin/grails-app/i18n/messages.spring-security-ui.properties
+++ b/plugin/grails-app/i18n/messages.spring-security-ui.properties
@@ -152,3 +152,7 @@ resetPasswordCommand.password.maxSize.exceeded Password must be between 8 and 64
 resetPasswordCommand.password.minSize.notmet Password must be between 8 and 64 characters
 
 forgotPasswordCommand.username.nullable Please enter your username
+
+spring.security.ui.invalid.save.form {0} may not have been created. Either the form was submitted twice or possible CSRF attempt. Be careful what you click.
+spring.security.ui.invalid.update.form {0} may not have been updated. Either the form was submitted twice or possible CSRF attempt. Be careful what you click.
+spring.security.ui.invalid.delete.form {0} may not have been deleted. Either the form was submitted twice or possible CSRF attempt. Be careful what you click.

--- a/plugin/grails-app/taglib/grails/plugin/springsecurity/ui/SecurityUiTagLib.groovy
+++ b/plugin/grails-app/taglib/grails/plugin/springsecurity/ui/SecurityUiTagLib.groovy
@@ -16,6 +16,7 @@ package grails.plugin.springsecurity.ui
 
 import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.ui.strategy.PropertiesStrategy
+import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 
 /**
  * @author <a href='mailto:burt@burtbeckwith.com'>Burt Beckwith</a>
@@ -174,53 +175,30 @@ class SecurityUiTagLib {
 	 * @attr focus    the element to focus on document ready
 	 * @attr idName   the name of the id property if it's not 'id'
 	 * @attr type     'save', 'update', 'login' if provided, only when not a child of formContainer
+	 * @attr useToken 'true' or 'false'.  Set to 'true' to prevent CSRF attacks
 	 */
 	def form = { attrs, body ->
 		attrs = [:] + attrs
 
-		String type = attrs.remove('type')
-		if (type) {
-			pageScope.s2uiFormType = type
-		}
-		else {
-			type = pageScope.s2uiFormType
-		}
-		assert type
-
-		def bean
-		String beanName = attrs.remove('beanName')
-		if (beanName) {
-			bean = pageScope.s2uiBean = pageScope.s2uiBeanType = pageScope[beanName]
-			assert bean
-		}
-		else {
-			bean = pageScope.s2uiBean
-		}
-
-		String cssClass = attrs.remove('class') ?: ''
-		if (cssClass) {
-			cssClass = """class="$cssClass" """
-		}
-
+		boolean useToken = extractFormUseToken(attrs)
+		String type = extractFormType(attrs)
+		def bean = extractFormBean(attrs)
+		String cssClass = extractFormCssClass(attrs)
 		String idName = attrs.remove('idName')
-		def id
-		if (bean && !(bean instanceof CommandObject)) {
-			id = idName ? bean[idName] : bean.id
-		}
-
+		def id = extractFormId(bean, idName)
 		String name = pageScope.s2uiFormName = type + 'Form'
 		String autocomplete = (type == 'login' || type.endsWith('Password')) ? ' autocomplete="off"' : ''
-
-		String link
-		if (type == 'login') {
-			link = "$request.contextPath$SpringSecurityUtils.securityConfig.apf.filterProcessesUrl"
-		}
-		else {
-			link = createLink(type)
-		}
+		String link = generateFormLink(type)
 
 		out << """
 			<form action="$link"$cssClass method="post" name="$name" id="$name"$autocomplete>"""
+
+		if (useToken) {
+			def tokensHolder = SynchronizerTokensHolder.store(session)
+			out << """
+					${hiddenField(name: SynchronizerTokensHolder.TOKEN_KEY, value: tokensHolder.generateToken(request.forwardURI))}
+					${hiddenField(name: SynchronizerTokensHolder.TOKEN_URI, value: request.forwardURI)}"""
+		}
 
 		if (type == 'update') {
 			out << """
@@ -242,6 +220,64 @@ class SecurityUiTagLib {
 		pageScope.s2uiBeanType = null
 		pageScope.s2uiFormName = null
 		pageScope.s2uiFormType = null
+	}
+
+	protected boolean extractFormUseToken(Map attrs) {
+		boolean useToken = false
+		if (attrs.containsKey('useToken')) {
+			useToken = attrs['useToken'].asBoolean()
+			attrs.remove('useToken')
+		}
+		return useToken
+	}
+
+	protected String generateFormLink(String type) {
+		String link
+		if (type == 'login') {
+			link = "$request.contextPath$SpringSecurityUtils.securityConfig.apf.filterProcessesUrl"
+		} else {
+			link = createLink(type)
+		}
+		return link
+	}
+
+	protected Object extractFormId(bean, String idName) {
+		def id
+		if (bean && !(bean instanceof CommandObject)) {
+			id = idName ? bean[idName] : bean.id
+		}
+		return id
+	}
+
+	protected String extractFormCssClass(Map attrs) {
+		String cssClass = attrs.remove('class') ?: ''
+		if (cssClass) {
+			cssClass = """class="$cssClass" """
+		}
+		return cssClass
+	}
+
+	protected Object extractFormBean(Map attrs) {
+		def bean
+		String beanName = attrs.remove('beanName')
+		if (beanName) {
+			bean = pageScope.s2uiBean = pageScope.s2uiBeanType = pageScope[beanName]
+			assert bean
+		} else {
+			bean = pageScope.s2uiBean
+		}
+		return bean
+	}
+
+	protected String extractFormType(Map attrs) {
+		String type = attrs.remove('type')
+		if (type) {
+			pageScope.s2uiFormType = type
+		} else {
+			type = pageScope.s2uiFormType
+		}
+		assert type
+		return type
 	}
 
 	/**

--- a/plugin/grails-app/taglib/grails/plugin/springsecurity/ui/SecurityUiTagLib.groovy
+++ b/plugin/grails-app/taglib/grails/plugin/springsecurity/ui/SecurityUiTagLib.groovy
@@ -130,16 +130,22 @@ class SecurityUiTagLib {
 
 	/**
 	 * @attr instanceId REQUIRED the id of the domain class instance
+	 * @attr useToken OPTIONAL
 	 */
 	def deleteButtonForm = { attrs ->
 		attrs = [:] + attrs
+		boolean useToken = extractFormUseToken(attrs)
 
 		def id = getRequiredAttribute(attrs, 'instanceId', 'deleteButton')
 
 		attrs.action = 'delete'
 
 		out << """
-			<form action="${createLink(attrs)}" method="post" name="deleteForm" id="deleteForm">
+			<form action="${createLink(attrs)}" method="post" name="deleteForm" id="deleteForm">"""
+
+		writeTokenFields(useToken)
+
+		out << """
 				<input type="hidden" name="id" value="$id" />
 			</form>
 			<div id="deleteConfirmDialog" title="${message(code:'default.button.delete.confirm.message')}"></div>"""
@@ -193,12 +199,7 @@ class SecurityUiTagLib {
 		out << """
 			<form action="$link"$cssClass method="post" name="$name" id="$name"$autocomplete>"""
 
-		if (useToken) {
-			def tokensHolder = SynchronizerTokensHolder.store(session)
-			out << """
-					${hiddenField(name: SynchronizerTokensHolder.TOKEN_KEY, value: tokensHolder.generateToken(request.forwardURI))}
-					${hiddenField(name: SynchronizerTokensHolder.TOKEN_URI, value: request.forwardURI)}"""
-		}
+		writeTokenFields(useToken)
 
 		if (type == 'update') {
 			out << """
@@ -220,6 +221,15 @@ class SecurityUiTagLib {
 		pageScope.s2uiBeanType = null
 		pageScope.s2uiFormName = null
 		pageScope.s2uiFormType = null
+	}
+
+	protected void writeTokenFields(boolean useToken) {
+		if (useToken) {
+			def tokensHolder = SynchronizerTokensHolder.store(session)
+			out << """
+					${hiddenField(name: SynchronizerTokensHolder.TOKEN_KEY, value: tokensHolder.generateToken(request.forwardURI))}
+					${hiddenField(name: SynchronizerTokensHolder.TOKEN_URI, value: request.forwardURI)}"""
+		}
 	}
 
 	protected boolean extractFormUseToken(Map attrs) {

--- a/plugin/grails-app/views/aclClass/create.gsp
+++ b/plugin/grails-app/views/aclClass/create.gsp
@@ -6,7 +6,7 @@
 <body>
 <div class="body">
 	<s2ui:formContainer type='save' beanType='aclClass' focus='className' height='300'>
-		<s2ui:form>
+		<s2ui:form useToken="true">
 			<div class="dialog">
 				<br/>
 				<table>

--- a/plugin/grails-app/views/aclClass/edit.gsp
+++ b/plugin/grails-app/views/aclClass/edit.gsp
@@ -6,7 +6,7 @@
 <body>
 <div class="body">
 	<s2ui:formContainer type='update' beanType='aclClass' focus='className' height='300'>
-		<s2ui:form>
+		<s2ui:form useToken="true">
 			<div class="dialog">
 				<br/>
 				<table>

--- a/plugin/grails-app/views/aclClass/edit.gsp
+++ b/plugin/grails-app/views/aclClass/edit.gsp
@@ -27,7 +27,7 @@
 			</div>
 		</s2ui:form>
 	</s2ui:formContainer>
-	<g:if test='${aclClass}'><s2ui:deleteButtonForm instanceId='${aclClass.id}'/></g:if>
+	<g:if test='${aclClass}'><s2ui:deleteButtonForm instanceId='${aclClass.id}' useToken="true"/></g:if>
 </div>
 </body>
 </html>

--- a/plugin/grails-app/views/aclEntry/create.gsp
+++ b/plugin/grails-app/views/aclEntry/create.gsp
@@ -6,7 +6,7 @@
 <body>
 <div class="body">
 	<s2ui:formContainer type='save' beanType='aclEntry' focus='aclObjectIdentity'>
-		<s2ui:form>
+		<s2ui:form useToken="true">
 			<div class="dialog">
 				<br/>
 				<table>

--- a/plugin/grails-app/views/aclEntry/edit.gsp
+++ b/plugin/grails-app/views/aclEntry/edit.gsp
@@ -27,7 +27,7 @@
 			</div>
 		</s2ui:form>
 	</s2ui:formContainer>
-	<g:if test='${aclEntry}'><s2ui:deleteButtonForm instanceId='${aclEntry.id}'/></g:if>
+	<g:if test='${aclEntry}'><s2ui:deleteButtonForm instanceId='${aclEntry.id}' useToken="true"/></g:if>
 </div>
 </body>
 </html>

--- a/plugin/grails-app/views/aclEntry/edit.gsp
+++ b/plugin/grails-app/views/aclEntry/edit.gsp
@@ -6,7 +6,7 @@
 <body>
 <div class="body">
 	<s2ui:formContainer type='update' beanType='aclEntry' focus='sid'>
-		<s2ui:form>
+		<s2ui:form useToken="true">
 			<div class="dialog">
 				<br/>
 				<table>

--- a/plugin/grails-app/views/aclObjectIdentity/create.gsp
+++ b/plugin/grails-app/views/aclObjectIdentity/create.gsp
@@ -6,7 +6,7 @@
 <body>
 <div class="body">
 	<s2ui:formContainer type='save' beanType='aclObjectIdentity' focus='objectId'>
-		<s2ui:form>
+		<s2ui:form useToken="true">
 			<div class="dialog">
 				<br/>
 				<table>

--- a/plugin/grails-app/views/aclObjectIdentity/edit.gsp
+++ b/plugin/grails-app/views/aclObjectIdentity/edit.gsp
@@ -6,7 +6,7 @@
 <body>
 <div class="body">
 	<s2ui:formContainer type='update' beanType='aclObjectIdentity' focus='sid'>
-		<s2ui:form>
+		<s2ui:form useToken="true">
 			<div class="dialog">
 				<br/>
 				<table>

--- a/plugin/grails-app/views/aclObjectIdentity/edit.gsp
+++ b/plugin/grails-app/views/aclObjectIdentity/edit.gsp
@@ -28,7 +28,7 @@
 			</div>
 		</s2ui:form>
 	</s2ui:formContainer>
-	<g:if test='${aclObjectIdentity}'><s2ui:deleteButtonForm instanceId='${aclObjectIdentity.id}'/></g:if>
+	<g:if test='${aclObjectIdentity}'><s2ui:deleteButtonForm instanceId='${aclObjectIdentity.id}' useToken="true"/></g:if>
 </div>
 </body>
 </html>

--- a/plugin/grails-app/views/aclSid/create.gsp
+++ b/plugin/grails-app/views/aclSid/create.gsp
@@ -6,7 +6,7 @@
 <body>
 <div class="body">
 	<s2ui:formContainer type='save' beanType='aclSid' focus='sid'>
-		<s2ui:form>
+		<s2ui:form useToken="true">
 			<div class="dialog">
 				<br/>
 				<table>

--- a/plugin/grails-app/views/aclSid/edit.gsp
+++ b/plugin/grails-app/views/aclSid/edit.gsp
@@ -6,7 +6,7 @@
 <body>
 <div class="body">
 	<s2ui:formContainer type='update' beanType='aclSid' focus='sid'>
-		<s2ui:form>
+		<s2ui:form useToken="true">
 			<div class="dialog">
 				<br/>
 				<table>

--- a/plugin/grails-app/views/aclSid/edit.gsp
+++ b/plugin/grails-app/views/aclSid/edit.gsp
@@ -32,7 +32,7 @@
 			</div>
 		</s2ui:form>
 	</s2ui:formContainer>
-	<g:if test='${aclSid}'><s2ui:deleteButtonForm instanceId='${aclSid.id}'/></g:if>
+	<g:if test='${aclSid}'><s2ui:deleteButtonForm instanceId='${aclSid.id}' useToken="true"/></g:if>
 </div>
 </body>
 </html>

--- a/plugin/grails-app/views/persistentLogin/edit.gsp
+++ b/plugin/grails-app/views/persistentLogin/edit.gsp
@@ -6,7 +6,7 @@
 <body>
 <div class="body">
 	<s2ui:formContainer type='update' beanType='persistentLogin' focus='token' height='350'>
-		<s2ui:form idName='series'>
+		<s2ui:form idName='series' useToken="true">
 			<div class="dialog">
 				<br/>
 				<table>

--- a/plugin/grails-app/views/persistentLogin/edit.gsp
+++ b/plugin/grails-app/views/persistentLogin/edit.gsp
@@ -34,7 +34,7 @@
 			</div>
 		</s2ui:form>
 	</s2ui:formContainer>
-	<g:if test='${persistentLogin}'><s2ui:deleteButtonForm instanceId='${persistentLogin.series}'/></g:if>
+	<g:if test='${persistentLogin}'><s2ui:deleteButtonForm instanceId='${persistentLogin.series}' useToken="true"/></g:if>
 </div>
 </body>
 </html>

--- a/plugin/grails-app/views/registrationCode/edit.gsp
+++ b/plugin/grails-app/views/registrationCode/edit.gsp
@@ -28,7 +28,7 @@
 			</div>
 		</s2ui:form>
 	</s2ui:formContainer>
-	<g:if test='${registrationCode}'><s2ui:deleteButtonForm instanceId='${registrationCode.id}'/></g:if>
+	<g:if test='${registrationCode}'><s2ui:deleteButtonForm instanceId='${registrationCode.id}' useToken="true"/></g:if>
 </div>
 <s2ui:ajaxSearch paramName='username'/>
 </body>

--- a/plugin/grails-app/views/registrationCode/edit.gsp
+++ b/plugin/grails-app/views/registrationCode/edit.gsp
@@ -6,7 +6,7 @@
 <body>
 <div class="body">
 	<s2ui:formContainer type='update' beanType='registrationCode' height='350'>
-		<s2ui:form>
+		<s2ui:form useToken="true">
 			<div class="dialog">
 				<br/>
 				<table>

--- a/plugin/grails-app/views/requestmap/create.gsp
+++ b/plugin/grails-app/views/requestmap/create.gsp
@@ -6,7 +6,7 @@
 <body>
 <div class="body">
 	<s2ui:formContainer type='save' beanType='requestmap' focus='url' height='350'>
-		<s2ui:form>
+		<s2ui:form useToken="true">
 			<div class="dialog">
 				<br/>
 				<table>

--- a/plugin/grails-app/views/requestmap/edit.gsp
+++ b/plugin/grails-app/views/requestmap/edit.gsp
@@ -6,7 +6,7 @@
 <body>
 <div class="body">
 	<s2ui:formContainer type='update' beanType='requestmap' focus='url' height='350'>
-		<s2ui:form>
+		<s2ui:form useToken="true">
 			<div class="dialog">
 				<br/>
 				<table>

--- a/plugin/grails-app/views/requestmap/edit.gsp
+++ b/plugin/grails-app/views/requestmap/edit.gsp
@@ -29,7 +29,7 @@
 		</s2ui:form>
 	</s2ui:formContainer>
 	<g:if test='${requestmap}'>
-		<s2ui:deleteButtonForm instanceId='${requestmap.id}'/>
+		<s2ui:deleteButtonForm instanceId='${requestmap.id}' useToken="true"/>
 	</g:if>
 </div>
 </body>

--- a/plugin/grails-app/views/role/create.gsp
+++ b/plugin/grails-app/views/role/create.gsp
@@ -6,7 +6,7 @@
 <body>
 <div class="body">
 	<s2ui:formContainer type='save' beanType='role' focus='authority' height='300'>
-		<s2ui:form>
+		<s2ui:form useToken="true">
 			<div class="dialog">
 				<br/>
 				<table>

--- a/plugin/grails-app/views/role/edit.gsp
+++ b/plugin/grails-app/views/role/edit.gsp
@@ -26,6 +26,6 @@
 		<g:if test='${role}'><s2ui:deleteButton/></g:if>
 	</div>
 </s2ui:form>
-<g:if test='${role}'><s2ui:deleteButtonForm instanceId='${role.id}'/></g:if>
+<g:if test='${role}'><s2ui:deleteButtonForm instanceId='${role.id}' useToken="true"/></g:if>
 </body>
 </html>

--- a/plugin/grails-app/views/role/edit.gsp
+++ b/plugin/grails-app/views/role/edit.gsp
@@ -5,7 +5,7 @@
 </head>
 <body>
 <h3><g:message code='default.edit.label' args='[entityName]'/></h3>
-<s2ui:form type='update' beanName='role'>
+<s2ui:form type='update' beanName='role' useToken="true">
 	<s2ui:tabs elementId='tabs' height='150' data='${tabData}'>
 		<s2ui:tab name='roleinfo' height='150'>
 			<table>

--- a/plugin/grails-app/views/user/create.gsp
+++ b/plugin/grails-app/views/user/create.gsp
@@ -5,7 +5,7 @@
 </head>
 <body>
 <h3><g:message code='default.create.label' args='[entityName]'/></h3>
-<s2ui:form type='save' beanName='user' focus='username'>
+<s2ui:form type='save' beanName='user' focus='username' useToken='true'>
 	<s2ui:tabs elementId='tabs' height='375' data='${tabData}'>
 		<s2ui:tab name='userinfo' height='280'>
 			<table>

--- a/plugin/grails-app/views/user/edit.gsp
+++ b/plugin/grails-app/views/user/edit.gsp
@@ -41,7 +41,7 @@
 		<g:if test='${canRunAs}'><a id="runAsButton">${message(code:'spring.security.ui.runas.submit')}</a></g:if>
 	</div>
 </s2ui:form>
-<g:if test='${user}'><s2ui:deleteButtonForm instanceId='${user.id}'/></g:if>
+<g:if test='${user}'><s2ui:deleteButtonForm instanceId='${user.id}' useToken="true"/></g:if>
 <g:if test='${canRunAs}'>
 <form name="runAsForm" action="${request.contextPath}${securityConfig.switchUser.switchUserUrl}" method='post'>
 	<g:hiddenField name='${securityConfig.switchUser.usernameParameter}' value='${username}'/>

--- a/plugin/grails-app/views/user/edit.gsp
+++ b/plugin/grails-app/views/user/edit.gsp
@@ -11,7 +11,7 @@
 </head>
 <body>
 <h3><g:message code='default.edit.label' args='[entityName]'/></h3>
-<s2ui:form type='update' beanName='user' focus='username' class='button-style'>
+<s2ui:form type='update' beanName='user' focus='username' class='button-style' useToken='true'>
 	<s2ui:tabs elementId='tabs' height='375' data='${tabData}'>
 		<s2ui:tab name='userinfo' height='275'>
 			<table>


### PR DESCRIPTION
This PR protects against CSRF attacks by using the `useToken` attribute within forms.

Many files were changed.  I've left commits intact, rather than squashing them, in an effort to making reviewing easier.

**Summary of changes**

• refactored `SecurityUiTagLib.form` by moving attribute extraction logic into small, protected methods
• modified `SecurityUiTagLib.form` to support `useToken` attribute
• refactored `SecurityUiTagLib.deleteButtonForm` to support `useToken` attribute. This may be used to prevent against CSRF attacks
• modified the following controllers and related views to use `useToken="true"` attribute to protect against CSRF attacks
    • `UserController` 
    •  `AclClassController` 
    • `AclEntryController`
    • `AclObjectIdentityController`
    • `AclSidController`
    • `RegistrationCodeController`
    • `RegistrationCodeController`
    • `PersistentLoginController`
    • `RequestmapController`
• refactored `AbstractS2UiDomainjController` and controllers which extend it to remove code duplication when handling requests with invalid tokens
• removed unused imports
• modified documentation to include a reference to CSRF protection

Fixes issue #9 