### PR TITLE
Issue 32: generateLink function should use grails.serverURL in configuration

### DIFF
--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
@@ -18,6 +18,7 @@ import grails.plugin.springsecurity.authentication.dao.NullSaltSource
 import grails.plugin.springsecurity.ui.strategy.MailStrategy
 import grails.plugin.springsecurity.ui.strategy.PropertiesStrategy
 import grails.plugin.springsecurity.ui.strategy.RegistrationCodeStrategy
+import grails.util.Holders
 import groovy.text.SimpleTemplateEngine
 import org.springframework.security.authentication.dao.SaltSource
 
@@ -178,9 +179,11 @@ class RegisterController extends AbstractS2UiController {
 	}
 
 	protected String generateLink(String action, Map linkParams, boolean absolute = false) {
-		String base = absolute ? null : "$request.scheme://$request.serverName:$request.serverPort$request.contextPath"
+		String base = "$request.scheme://$request.serverName:$request.serverPort$request.contextPath"
+		if (absolute && Holders.config.grails.serverURL) {
+			base = grailsApplication.config.grails.serverURL
+		}
 		createLink(
-				absolute: absolute,
 				base: base,
 				controller: 'register',
 				action: action,

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
@@ -178,9 +178,17 @@ class RegisterController extends AbstractS2UiController {
 		redirect uri: registerPostResetUrl ?: successHandlerDefaultTargetUrl
 	}
 
-	protected String generateLink(String action, Map linkParams, boolean absolute = false) {
+	/**
+	 *
+	 * @param action
+	 * @param linkParams
+	 * @param shouldUseServerUrl if true, will utilize the configured grails.serverURL from application.yml if it exists otherwise the base url will be
+	 * constructed the same as it always has been
+	 * @return
+	 */
+	protected String generateLink(String action, Map linkParams, boolean shouldUseServerUrl = false) {
 		String base = "$request.scheme://$request.serverName:$request.serverPort$request.contextPath"
-		if (absolute && Holders.config.grails.serverURL) {
+		if (shouldUseServerUrl && Holders.config.grails.serverURL) {
 			base = grailsApplication.config.grails.serverURL
 		}
 		createLink(

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
@@ -177,9 +177,14 @@ class RegisterController extends AbstractS2UiController {
 		redirect uri: registerPostResetUrl ?: successHandlerDefaultTargetUrl
 	}
 
-	protected String generateLink(String action, linkParams) {
-		createLink(base: "$request.scheme://$request.serverName:$request.serverPort$request.contextPath",
-		           controller: 'register', action: action, params: linkParams)
+	protected String generateLink(String action, Map linkParams, boolean absolute = false) {
+		String base = absolute ? null : "$request.scheme://$request.serverName:$request.serverPort$request.contextPath"
+		createLink(
+				absolute: absolute,
+				base: base,
+				controller: 'register',
+				action: action,
+				params: linkParams)
 	}
 
 	protected String evaluate(s, binding) {

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
@@ -179,12 +179,11 @@ class RegisterController extends AbstractS2UiController {
 	}
 
 	/**
-	 *
+	 * Creates a grails application link from a set of attributes.
 	 * @param action
 	 * @param linkParams
-	 * @param shouldUseServerUrl if true, will utilize the configured grails.serverURL from application.yml if it exists otherwise the base url will be
-	 * constructed the same as it always has been
-	 * @return
+	 * @param shouldUseServerUrl (optional) - If true, will utilize the configured grails.serverURL from application.yml if it exists otherwise the base url will be constructed the same as it always has been
+	 * @return String representing the relative or absolute URL
 	 */
 	protected String generateLink(String action, Map linkParams, boolean shouldUseServerUrl = false) {
 		String base = "$request.scheme://$request.serverName:$request.serverPort$request.contextPath"

--- a/plugin/src/test/groovy/grails/plugin/springsecurity/ui/RegisterControllerSpec.groovy
+++ b/plugin/src/test/groovy/grails/plugin/springsecurity/ui/RegisterControllerSpec.groovy
@@ -3,7 +3,9 @@ package grails.plugin.springsecurity.ui
 import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.testing.web.controllers.ControllerUnitTest
 import spock.lang.Specification
+import spock.lang.Unroll
 
+@Unroll
 class RegisterControllerSpec extends Specification implements ControllerUnitTest<RegisterController> {
 
     void setup() {
@@ -124,20 +126,23 @@ class RegisterControllerSpec extends Specification implements ControllerUnitTest
         !RegisterController.passwordValidator(password, command)
     }
 
-    void "verify generateLink functionality"() {
+    void "verify generateLink for ('#action', #linkParams, '#shouldUseServerUrl') is #expectedUrl"() {
         given: "the grails.serverUrl is set"
-        config.grails.serverURL = 'http://grails.org'
+        if (isConfigured) {
+            config.grails.serverURL = 'http://grails.org'
+        }
 
         when: "the generateLink method is called"
-        def results = controller.generateLink(action, linkParams, absolute)
+        def results = controller.generateLink(action, linkParams, shouldUseServerUrl)
 
         then: "the configured grails.serverUrl is used if the absolute parameter is true"
         results == expectedUrl
 
         where:
-        absolute | action   | linkParams               | expectedUrl
-        false    | 'shipit' | [foo: 'foo', bar: 'bar'] | 'http://localhost:80/register/shipit?foo=foo&bar=bar'
-        true     | 'shipit' | [foo: 'foo', bar: 'bar'] | 'http://grails.org/register/shipit?foo=foo&bar=bar'
+        isConfigured | shouldUseServerUrl | action   | linkParams               | expectedUrl
+        false        | false              | 'shipit' | [foo: 'foo', bar: 'bar'] | 'http://localhost:80/register/shipit?foo=foo&bar=bar'
+        false        | true               | 'shipit' | [foo: 'foo', bar: 'bar'] | 'http://localhost:80/register/shipit?foo=foo&bar=bar'
+        true         | true               | 'shipit' | [foo: 'foo', bar: 'bar'] | 'http://grails.org/register/shipit?foo=foo&bar=bar'
     }
 
     private void updateFromConfig() {

--- a/plugin/src/test/groovy/grails/plugin/springsecurity/ui/RegisterControllerSpec.groovy
+++ b/plugin/src/test/groovy/grails/plugin/springsecurity/ui/RegisterControllerSpec.groovy
@@ -2,7 +2,6 @@ package grails.plugin.springsecurity.ui
 
 import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.testing.web.controllers.ControllerUnitTest
-import spock.lang.IgnoreRest
 import spock.lang.Specification
 
 class RegisterControllerSpec extends Specification implements ControllerUnitTest<RegisterController> {
@@ -125,10 +124,9 @@ class RegisterControllerSpec extends Specification implements ControllerUnitTest
         !RegisterController.passwordValidator(password, command)
     }
 
-    @IgnoreRest
     void "verify generateLink functionality"() {
         given: "the grails.serverUrl is set"
-        config.grails.serverUrl = 'http://grails.org'
+        config.grails.serverURL = 'http://grails.org'
 
         when: "the generateLink method is called"
         def results = controller.generateLink(action, linkParams, absolute)

--- a/plugin/src/test/groovy/grails/plugin/springsecurity/ui/RegisterControllerSpec.groovy
+++ b/plugin/src/test/groovy/grails/plugin/springsecurity/ui/RegisterControllerSpec.groovy
@@ -7,142 +7,142 @@ import spock.lang.Specification
 
 class RegisterControllerSpec extends Specification implements ControllerUnitTest<RegisterController> {
 
-	void setup() {
-		SpringSecurityUtils.setSecurityConfig [:] as ConfigObject
-		updateFromConfig()
-	}
+    void setup() {
+        SpringSecurityUtils.setSecurityConfig [:] as ConfigObject
+        updateFromConfig()
+    }
 
-	void cleanup() {
-		SpringSecurityUtils.resetSecurityConfig()
-	}
+    void cleanup() {
+        SpringSecurityUtils.resetSecurityConfig()
+    }
 
-	void 'passwordValidator validation fails if the password is the same as the username'() {
-		expect:
-		'command.password.error.username' == RegisterController.passwordValidator('username', [username: 'username'])
-	}
+    void 'passwordValidator validation fails if the password is the same as the username'() {
+        expect:
+        'command.password.error.username' == RegisterController.passwordValidator('username', [username: 'username'])
+    }
 
-	void 'passwordValidator validation strength check fails if the password is too short'() {
-		when:
-		def command = [username: 'username']
-		String password = 'h!Z7'
+    void 'passwordValidator validation strength check fails if the password is too short'() {
+        when:
+        def command = [username: 'username']
+        String password = 'h!Z7'
 
-		then:
-		!RegisterController.checkPasswordMinLength(password, command)
-		RegisterController.checkPasswordMaxLength password, command
-		RegisterController.checkPasswordRegex password, command
+        then:
+        !RegisterController.checkPasswordMinLength(password, command)
+        RegisterController.checkPasswordMaxLength password, command
+        RegisterController.checkPasswordRegex password, command
 
-		'command.password.error.length' == RegisterController.passwordValidator(password, command)[0]
-	}
+        'command.password.error.length' == RegisterController.passwordValidator(password, command)[0]
+    }
 
-	void 'passwordValidator validation fails if the password is too short'() {
-		when:
-		def command = [username: 'username']
-		String password = 'h!Z7'
-		SpringSecurityUtils.securityConfig.ui.password.minLength = 3
-		updateFromConfig()
+    void 'passwordValidator validation fails if the password is too short'() {
+        when:
+        def command = [username: 'username']
+        String password = 'h!Z7'
+        SpringSecurityUtils.securityConfig.ui.password.minLength = 3
+        updateFromConfig()
 
-		then:
-		RegisterController.checkPasswordMinLength password, command
-		RegisterController.checkPasswordMaxLength password, command
-		RegisterController.checkPasswordRegex password, command
+        then:
+        RegisterController.checkPasswordMinLength password, command
+        RegisterController.checkPasswordMaxLength password, command
+        RegisterController.checkPasswordRegex password, command
 
-		!RegisterController.passwordValidator(password, command)
-	}
+        !RegisterController.passwordValidator(password, command)
+    }
 
-	void 'passwordValidator validation strength check fails if the password is too long'() {
-		when:
-		def command = [username: 'username']
-		String password = 'h!Z7aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1'
+    void 'passwordValidator validation strength check fails if the password is too long'() {
+        when:
+        def command = [username: 'username']
+        String password = 'h!Z7aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1'
 
-		then:
-		RegisterController.checkPasswordMinLength password, command
-		!RegisterController.checkPasswordMaxLength(password, command)
-		RegisterController.checkPasswordRegex password, command
+        then:
+        RegisterController.checkPasswordMinLength password, command
+        !RegisterController.checkPasswordMaxLength(password, command)
+        RegisterController.checkPasswordRegex password, command
 
-		'command.password.error.length' == RegisterController.passwordValidator(password, command)[0]
-	}
+        'command.password.error.length' == RegisterController.passwordValidator(password, command)[0]
+    }
 
-	void 'passwordValidator validation fails if the password is too long'() {
-		when:
-		def command = [username: 'username']
-		String password = 'h!Z7aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1'
-		SpringSecurityUtils.securityConfig.ui.password.maxLength = 100
-		updateFromConfig()
+    void 'passwordValidator validation fails if the password is too long'() {
+        when:
+        def command = [username: 'username']
+        String password = 'h!Z7aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1'
+        SpringSecurityUtils.securityConfig.ui.password.maxLength = 100
+        updateFromConfig()
 
-		then:
-		RegisterController.checkPasswordMinLength password, command
-		RegisterController.checkPasswordMaxLength password, command
-		RegisterController.checkPasswordRegex password, command
+        then:
+        RegisterController.checkPasswordMinLength password, command
+        RegisterController.checkPasswordMaxLength password, command
+        RegisterController.checkPasswordRegex password, command
 
-		!RegisterController.passwordValidator(password, command)
-	}
+        !RegisterController.passwordValidator(password, command)
+    }
 
-	void 'passwordValidator validation fails if the default regex does not match'() {
-		when:
-		def command = [username: 'username']
-		String password = 'password'
+    void 'passwordValidator validation fails if the default regex does not match'() {
+        when:
+        def command = [username: 'username']
+        String password = 'password'
 
-		then:
-		RegisterController.checkPasswordMinLength password, command
-		RegisterController.checkPasswordMaxLength password, command
-		!RegisterController.checkPasswordRegex(password, command)
+        then:
+        RegisterController.checkPasswordMinLength password, command
+        RegisterController.checkPasswordMaxLength password, command
+        !RegisterController.checkPasswordRegex(password, command)
 
-		'command.password.error.strength' == RegisterController.passwordValidator(password, command)
+        'command.password.error.strength' == RegisterController.passwordValidator(password, command)
 
-		when:
-		password = 'h!Z7abcd'
+        when:
+        password = 'h!Z7abcd'
 
-		then:
-		RegisterController.checkPasswordMinLength password, command
-		RegisterController.checkPasswordMaxLength password, command
-		RegisterController.checkPasswordRegex password, command
+        then:
+        RegisterController.checkPasswordMinLength password, command
+        RegisterController.checkPasswordMaxLength password, command
+        RegisterController.checkPasswordRegex password, command
 
-		!RegisterController.passwordValidator(password, command)
-	}
+        !RegisterController.passwordValidator(password, command)
+    }
 
-	void 'passwordValidator validation fails if an updated regex does not match'() {
-		when:
-		def command = [username: 'username']
-		String password = 'h!Z7abcd'
-		SpringSecurityUtils.securityConfig.ui.password.validationRegex = '^.*s3cr3t.*$'
-		updateFromConfig()
+    void 'passwordValidator validation fails if an updated regex does not match'() {
+        when:
+        def command = [username: 'username']
+        String password = 'h!Z7abcd'
+        SpringSecurityUtils.securityConfig.ui.password.validationRegex = '^.*s3cr3t.*$'
+        updateFromConfig()
 
-		then:
-		RegisterController.checkPasswordMinLength password, command
-		RegisterController.checkPasswordMaxLength password, command
-		!RegisterController.checkPasswordRegex(password, command)
+        then:
+        RegisterController.checkPasswordMinLength password, command
+        RegisterController.checkPasswordMaxLength password, command
+        !RegisterController.checkPasswordRegex(password, command)
 
-		'command.password.error.strength' == RegisterController.passwordValidator(password, command)
+        'command.password.error.strength' == RegisterController.passwordValidator(password, command)
 
-		when:
-		password = '123_s3cr3t_asd'
+        when:
+        password = '123_s3cr3t_asd'
 
-		then:
-		RegisterController.checkPasswordMinLength password, command
-		RegisterController.checkPasswordMaxLength password, command
-		RegisterController.checkPasswordRegex password, command
+        then:
+        RegisterController.checkPasswordMinLength password, command
+        RegisterController.checkPasswordMaxLength password, command
+        RegisterController.checkPasswordRegex password, command
 
-		!RegisterController.passwordValidator(password, command)
-	}
+        !RegisterController.passwordValidator(password, command)
+    }
 
     @IgnoreRest
     void "verify generateLink functionality"() {
-		given: "the grails.serverUrl is set"
-		config.grails.serverUrl='http://grails.org'
+        given: "the grails.serverUrl is set"
+        config.grails.serverUrl = 'http://grails.org'
 
         when: "the generateLink method is called"
         def results = controller.generateLink(action, linkParams, absolute)
 
-		then: "the configured grails.serverUrl is used if the absolute parameter is true"
-		results == expectedUrl
+        then: "the configured grails.serverUrl is used if the absolute parameter is true"
+        results == expectedUrl
 
         where:
-        absolute | action | linkParams               | expectedUrl
+        absolute | action   | linkParams               | expectedUrl
         false    | 'shipit' | [foo: 'foo', bar: 'bar'] | 'http://localhost:80/register/shipit?foo=foo&bar=bar'
-		true     | 'shipit' | [foo: 'foo', bar: 'bar'] | 'http://grails.org/register/shipit?foo=foo&bar=bar'
+        true     | 'shipit' | [foo: 'foo', bar: 'bar'] | 'http://grails.org/register/shipit?foo=foo&bar=bar'
     }
 
-	private void updateFromConfig() {
-		new RegisterController().afterPropertiesSet()
-	}
+    private void updateFromConfig() {
+        new RegisterController().afterPropertiesSet()
+    }
 }

--- a/plugin/src/test/groovy/grails/plugin/springsecurity/ui/RegisterControllerSpec.groovy
+++ b/plugin/src/test/groovy/grails/plugin/springsecurity/ui/RegisterControllerSpec.groovy
@@ -1,9 +1,11 @@
 package grails.plugin.springsecurity.ui
 
 import grails.plugin.springsecurity.SpringSecurityUtils
+import grails.testing.web.controllers.ControllerUnitTest
+import spock.lang.IgnoreRest
 import spock.lang.Specification
 
-class RegisterControllerSpec extends Specification {
+class RegisterControllerSpec extends Specification implements ControllerUnitTest<RegisterController> {
 
 	void setup() {
 		SpringSecurityUtils.setSecurityConfig [:] as ConfigObject
@@ -122,6 +124,23 @@ class RegisterControllerSpec extends Specification {
 
 		!RegisterController.passwordValidator(password, command)
 	}
+
+    @IgnoreRest
+    void "verify generateLink functionality"() {
+		given: "the grails.serverUrl is set"
+		config.grails.serverUrl='http://grails.org'
+
+        when: "the generateLink method is called"
+        def results = controller.generateLink(action, linkParams, absolute)
+
+		then: "the configured grails.serverUrl is used if the absolute parameter is true"
+		results == expectedUrl
+
+        where:
+        absolute | action | linkParams               | expectedUrl
+        false    | 'shipit' | [foo: 'foo', bar: 'bar'] | 'http://localhost:80/register/shipit?foo=foo&bar=bar'
+		true     | 'shipit' | [foo: 'foo', bar: 'bar'] | 'http://grails.org/register/shipit?foo=foo&bar=bar'
+    }
 
 	private void updateFromConfig() {
 		new RegisterController().afterPropertiesSet()


### PR DESCRIPTION
Made changes so that the generated link will utilize the `grails.serveURL` value if
1. it's specified in the app's `application.yml`
2. the `shouldUseServerUrl` param is `true`

This will make it easier for users to override the `RegisterController` and force it to use the value of `serverURLl` from `application.yml` if desired