### PR TITLE
Issue 32: generateLink function should use grails.serverURL in configuration

### DIFF
--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
@@ -14,6 +14,8 @@
  */
 package grails.plugin.springsecurity.ui
 
+import grails.config.Config
+import grails.core.support.GrailsConfigurationAware
 import grails.plugin.springsecurity.authentication.dao.NullSaltSource
 import grails.plugin.springsecurity.ui.strategy.MailStrategy
 import grails.plugin.springsecurity.ui.strategy.PropertiesStrategy
@@ -25,7 +27,7 @@ import org.springframework.security.authentication.dao.SaltSource
 /**
  * @author <a href='mailto:burt@burtbeckwith.com'>Burt Beckwith</a>
  */
-class RegisterController extends AbstractS2UiController {
+class RegisterController extends AbstractS2UiController implements GrailsConfigurationAware {
 
 	static defaultAction = 'register'
 
@@ -40,6 +42,13 @@ class RegisterController extends AbstractS2UiController {
 
 	/** Dependency injection for the 'uiPropertiesStrategy' bean. */
 	PropertiesStrategy uiPropertiesStrategy
+
+	String serverURL
+
+	@Override
+	void setConfiguration(Config co) {
+		serverURL = co.getProperty('grails.serverURL', String)
+	}
 
 	def register(RegisterCommand registerCommand) {
 
@@ -188,8 +197,8 @@ class RegisterController extends AbstractS2UiController {
 	protected String generateLink(String action, Map linkParams, boolean shouldUseServerUrl = false) {
 		String base = "$request.scheme://$request.serverName:$request.serverPort$request.contextPath"
 
-		if (shouldUseServerUrl && Holders.config.grails.serverURL) {
-			base = grailsApplication.config.grails.serverURL
+		if (shouldUseServerUrl && serverURL) {
+			base = serverURL
 		}
 
 		createLink(

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
@@ -18,6 +18,7 @@ import grails.plugin.springsecurity.authentication.dao.NullSaltSource
 import grails.plugin.springsecurity.ui.strategy.MailStrategy
 import grails.plugin.springsecurity.ui.strategy.PropertiesStrategy
 import grails.plugin.springsecurity.ui.strategy.RegistrationCodeStrategy
+import grails.util.Holders
 import groovy.text.SimpleTemplateEngine
 import org.springframework.security.authentication.dao.SaltSource
 
@@ -177,9 +178,25 @@ class RegisterController extends AbstractS2UiController {
 		redirect uri: registerPostResetUrl ?: successHandlerDefaultTargetUrl
 	}
 
-	protected String generateLink(String action, linkParams) {
-		createLink(base: "$request.scheme://$request.serverName:$request.serverPort$request.contextPath",
-		           controller: 'register', action: action, params: linkParams)
+	/**
+	 * Creates a grails application link from a set of attributes.
+	 * @param action
+	 * @param linkParams
+	 * @param shouldUseServerUrl (optional) - If true, will utilize the configured grails.serverURL from application.yml if it exists otherwise the base url will be constructed the same as it always has been
+	 * @return String representing the relative or absolute URL
+	 */
+	protected String generateLink(String action, Map linkParams, boolean shouldUseServerUrl = false) {
+		String base = "$request.scheme://$request.serverName:$request.serverPort$request.contextPath"
+
+		if (shouldUseServerUrl && Holders.config.grails.serverURL) {
+			base = grailsApplication.config.grails.serverURL
+		}
+
+		createLink(
+				base: base,
+				controller: 'register',
+				action: action,
+				params: linkParams)
 	}
 
 	protected String evaluate(s, binding) {

--- a/plugin/src/test/groovy/grails/plugin/springsecurity/ui/RegisterControllerSpec.groovy
+++ b/plugin/src/test/groovy/grails/plugin/springsecurity/ui/RegisterControllerSpec.groovy
@@ -1,9 +1,12 @@
 package grails.plugin.springsecurity.ui
 
 import grails.plugin.springsecurity.SpringSecurityUtils
+import grails.testing.web.controllers.ControllerUnitTest
 import spock.lang.Specification
+import spock.lang.Unroll
 
-class RegisterControllerSpec extends Specification {
+@Unroll
+class RegisterControllerSpec extends Specification implements ControllerUnitTest<RegisterController> {
 
 	void setup() {
 		SpringSecurityUtils.setSecurityConfig [:] as ConfigObject
@@ -122,6 +125,25 @@ class RegisterControllerSpec extends Specification {
 
 		!RegisterController.passwordValidator(password, command)
 	}
+
+    void "verify generateLink for ('#action', #linkParams, '#shouldUseServerUrl') is #expectedUrl"() {
+        given: "the grails.serverUrl is set"
+        if (isConfigured) {
+            config.grails.serverURL = 'http://grails.org'
+        }
+
+        when: "the generateLink method is called"
+        def results = controller.generateLink(action, linkParams, shouldUseServerUrl)
+
+        then: "the configured grails.serverUrl is used if the absolute parameter is true"
+        results == expectedUrl
+
+        where:
+        isConfigured | shouldUseServerUrl | action   | linkParams               | expectedUrl
+        false        | false              | 'shipit' | [foo: 'foo', bar: 'bar'] | 'http://localhost:80/register/shipit?foo=foo&bar=bar'
+        false        | true               | 'shipit' | [foo: 'foo', bar: 'bar'] | 'http://localhost:80/register/shipit?foo=foo&bar=bar'
+        true         | true               | 'shipit' | [foo: 'foo', bar: 'bar'] | 'http://grails.org/register/shipit?foo=foo&bar=bar'
+    }
 
 	private void updateFromConfig() {
 		new RegisterController().afterPropertiesSet()


### PR DESCRIPTION
Made changes so that the generated link will utilize the `grails.serveURL` value if
1. `grails.serveURL` is specified in the app's `application.yml` or other external config file
2. the `shouldUseServerUrl` param is `true`

This will make it easier for users to override the `RegisterController` and force it to use the value of `serverURL` from `application.yml` if desired.

This addresses the problem reported in issue #32