### PR TITLE
Issue 43: email i18n files

### DIFF
--- a/docs/src/docs/customization.adoc
+++ b/docs/src/docs/customization.adoc
@@ -66,9 +66,12 @@ The files copied for each type are summarized here:
 
 * register
 ** `controller/RegisterController.groovy`
+** `views/layouts/email.gsp`
 ** `views/register/forgotPassword.gsp`
+** `views/register/_forgotPasswordMail.gsp`
 ** `views/register/register.gsp`
 ** `views/register/resetPassword.gsp`
+** `views/register/_verifyRegistrationMail.gsp`
 
 * registrationcode
 ** `controller/RegistrationCodeController.groovy`

--- a/examples/extended/src/integration-test/groovy/GebConfig.groovy
+++ b/examples/extended/src/integration-test/groovy/GebConfig.groovy
@@ -1,10 +1,8 @@
 // See: http://www.gebish.org/manual/current/configuration.html
 import org.openqa.selenium.chrome.ChromeOptions
 import org.openqa.selenium.chrome.ChromeDriver
-quitCachedDriverOnShutdown = true
 
 environments {
-
 
 	chrome {
 		driver = { new ChromeDriver() }

--- a/examples/simple/src/integration-test/groovy/GebConfig.groovy
+++ b/examples/simple/src/integration-test/groovy/GebConfig.groovy
@@ -2,8 +2,6 @@
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.chrome.ChromeOptions
 
-quitCachedDriverOnShutdown = true
-
 environments {
 
 	chrome {

--- a/plugin/grails-app/conf/DefaultUiSecurityConfig.groovy
+++ b/plugin/grails-app/conf/DefaultUiSecurityConfig.groovy
@@ -19,17 +19,7 @@ security {
 		encodePassword = false
 
 		forgotPassword {
-			emailBody = '''\
-Hi $user.username,<br/>
-<br/>
-You (or someone pretending to be you) requested that your password be reset.<br/>
-<br/>
-If you didn't make this request then ignore the email; no changes have been made.<br/>
-<br/>
-If you did make the request, then click <a href="$url">here</a> to reset your password.
-'''
-			emailFrom = 'do.not.reply@localhost'
-			emailSubject = 'Password Reset'
+			emailFrom = 'Do Not Reply <do.not.reply@localhost>'
 			postResetUrl = null // use defaultTargetUrl if not set
 		}
 
@@ -40,15 +30,7 @@ If you did make the request, then click <a href="$url">here</a> to reset your pa
 
 		register {
 			defaultRoleNames = ['ROLE_USER']
-			emailBody = '''\
-Hi $user.username,<br/>
-<br/>
-You (or someone pretending to be you) created an account with this email address.<br/>
-<br/>
-If you made the request, please click&nbsp;<a href="$url">here</a> to finish the registration.
-'''
-			emailFrom = 'do.not.reply@localhost'
-			emailSubject = 'New Account'
+			emailFrom = 'Do Not Reply <do.not.reply@localhost>'
 			postRegisterUrl = null // use defaultTargetUrl if not set
 		}
 

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
@@ -273,7 +273,7 @@ class RegisterController extends AbstractS2UiController implements GrailsConfigu
 		forgotPasswordEmailBody = conf.ui.forgotPassword.emailBody ?: ''
 		registerEmailBody = conf.ui.register.emailBody ?: ''
 		registerEmailFrom = conf.ui.register.emailFrom ?: ''
-		registerEmailSubject = conf.ui.register.emailSubject ?: messageSource ? messageSource.getMessage('spring.security.ui.register.email.subject', [].toArray(), LocaleContextHolder.locale) : '' ?: ''
+		registerEmailSubject = conf.ui.register.emailSubject ?: messageSource ? messageSource.getMessage('spring.security.ui.register.email.subject', [].toArray(), 'New Account', LocaleContextHolder.locale) : '' ?: ''
 		registerPostRegisterUrl = conf.ui.register.postRegisterUrl ?: ''
 		registerPostResetUrl = conf.ui.forgotPassword.postResetUrl ?: ''
 		successHandlerDefaultTargetUrl = conf.successHandler.defaultTargetUrl ?: '/'

--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/RegisterController.groovy
@@ -181,10 +181,8 @@ class RegisterController extends AbstractS2UiController implements GrailsConfigu
 								username: user.username
 						]
 				)
-			} else {
-				(body.contains('$')) {
-					body = evaluate(body, [user: user, url: url])
-				}
+			} else if (body.contains('$')) {
+				body = evaluate(body, [user: user, url: url])
 			}
 
 			body

--- a/plugin/grails-app/i18n/messages.spring-security-ui.properties
+++ b/plugin/grails-app/i18n/messages.spring-security-ui.properties
@@ -116,6 +116,13 @@ spring.security.ui.forgotPassword.submit Reset my password
 spring.security.ui.forgotPassword.title Forgot Password
 spring.security.ui.forgotPassword.user.notFound No user was found with that username
 spring.security.ui.forgotPassword.username Username
+spring.security.ui.forgotPassword.email.subject Password Reset
+spring.security.ui.forgotPassword.email.greeting Hi {0}
+spring.security.ui.forgotPassword.email.here here
+spring.security.ui.forgotPassword.email.line1 You (or someone pretending to be you) requested that your password be reset.
+spring.security.ui.forgotPassword.email.line2 If you didn't make this request then ignore the email; no changes have been made.
+spring.security.ui.forgotPassword.email.line3 If you did make the request, then click
+spring.security.ui.forgotPassword.email.line4 to reset your password.
 
 spring.security.ui.register.badCode Sorry, we have no record of that request, or it has expired
 spring.security.ui.register.complete Your registration is complete
@@ -125,6 +132,12 @@ spring.security.ui.register.miscError Sorry, there was a problem processing your
 spring.security.ui.register.sent Your account registration email was sent - check your mail!
 spring.security.ui.register.submit Create your account
 spring.security.ui.register.title Register
+spring.security.ui.register.email.subject New Account
+spring.security.ui.register.email.greeting Hi {0}
+spring.security.ui.register.email.here here
+spring.security.ui.register.email.line1 You (or someone pretending to be you) created an account with this email address.
+spring.security.ui.register.email.line2 If you made the request, please click
+spring.security.ui.register.email.line3 to finish the registration.
 
 spring.security.ui.resetPassword.badCode Sorry, we have no record of that request, or it has expired
 spring.security.ui.resetPassword.description Enter your new password

--- a/plugin/grails-app/services/grails/plugin/springsecurity/ui/SpringSecurityUiService.groovy
+++ b/plugin/grails-app/services/grails/plugin/springsecurity/ui/SpringSecurityUiService.groovy
@@ -691,7 +691,7 @@ class SpringSecurityUiService implements AclStrategy, ErrorsStrategy, Persistent
 		encodePassword = encode instanceof Boolean ? encode : false
 
 		forgotPasswordEmailFrom = conf.ui.forgotPassword.emailFrom ?: ''
-		forgotPasswordEmailSubject = conf.ui.forgotPassword.emailSubject ?: messageSource ? messageSource.getMessage('spring.security.ui.forgotPassword.email.subject', [].toArray(), LocaleContextHolder.locale) : '' ?: ''
+		forgotPasswordEmailSubject = conf.ui.forgotPassword.emailSubject ?: messageSource ? messageSource.getMessage('spring.security.ui.forgotPassword.email.subject', [].toArray(), 'Password Reset', LocaleContextHolder.locale) : '' ?: ''
 
 		registerDefaultRoleNames = conf.ui.register.defaultRoleNames ?: []
 

--- a/plugin/grails-app/services/grails/plugin/springsecurity/ui/SpringSecurityUiService.groovy
+++ b/plugin/grails-app/services/grails/plugin/springsecurity/ui/SpringSecurityUiService.groovy
@@ -212,7 +212,7 @@ class SpringSecurityUiService implements AclStrategy, ErrorsStrategy, Persistent
 			uiMailStrategy.sendForgotPasswordMail(
 					to: emailAddress,
 					from: forgotPasswordEmailFrom,
-					subject: messageSource.getMessage('spring.security.ui.forgotPassword.email.subject', [].toArray(), LocaleContextHolder.locale),
+					subject: forgotPasswordEmailSubject,
 					html: emailBodyGenerator(registrationCode.token))
 		}
 
@@ -670,6 +670,7 @@ class SpringSecurityUiService implements AclStrategy, ErrorsStrategy, Persistent
 
 	protected boolean encodePassword
 	protected String forgotPasswordEmailFrom
+	protected String forgotPasswordEmailSubject
 	protected List<String> registerDefaultRoleNames
 
 	protected Class<?> AclClass
@@ -690,6 +691,7 @@ class SpringSecurityUiService implements AclStrategy, ErrorsStrategy, Persistent
 		encodePassword = encode instanceof Boolean ? encode : false
 
 		forgotPasswordEmailFrom = conf.ui.forgotPassword.emailFrom ?: ''
+		forgotPasswordEmailSubject = conf.ui.forgotPassword.emailSubject ?: messageSource ? messageSource.getMessage('spring.security.ui.forgotPassword.email.subject', [].toArray(), LocaleContextHolder.locale) : '' ?: ''
 
 		registerDefaultRoleNames = conf.ui.register.defaultRoleNames ?: []
 

--- a/plugin/grails-app/services/grails/plugin/springsecurity/ui/SpringSecurityUiService.groovy
+++ b/plugin/grails-app/services/grails/plugin/springsecurity/ui/SpringSecurityUiService.groovy
@@ -205,15 +205,15 @@ class SpringSecurityUiService implements AclStrategy, ErrorsStrategy, Persistent
 	}
 
 	@Transactional
-	RegistrationCode sendForgotPasswordMail(String username, String emailAddress,
-	                                        Closure emailBodyGenerator) {
+	RegistrationCode sendForgotPasswordMail(String username, String emailAddress, Closure emailBodyGenerator) {
 
-		RegistrationCode registrationCode = save(username: username, RegistrationCode,
-			'sendForgotPasswordMail', transactionStatus)
+		RegistrationCode registrationCode = save(username: username, RegistrationCode, 'sendForgotPasswordMail', transactionStatus)
 		if (!registrationCode.hasErrors()) {
-			String body = emailBodyGenerator(registrationCode.token)
-			uiMailStrategy.sendForgotPasswordMail(to: emailAddress, from: forgotPasswordEmailFrom,
-		                                         subject: forgotPasswordEmailSubject, html: body)
+			uiMailStrategy.sendForgotPasswordMail(
+					to: emailAddress,
+					from: forgotPasswordEmailFrom,
+					subject: messageSource.getMessage('spring.security.ui.forgotPassword.email.subject', [].toArray(), LocaleContextHolder.locale),
+					html: emailBodyGenerator(registrationCode.token))
 		}
 
 		registrationCode
@@ -670,7 +670,6 @@ class SpringSecurityUiService implements AclStrategy, ErrorsStrategy, Persistent
 
 	protected boolean encodePassword
 	protected String forgotPasswordEmailFrom
-	protected String forgotPasswordEmailSubject
 	protected List<String> registerDefaultRoleNames
 
 	protected Class<?> AclClass
@@ -691,7 +690,6 @@ class SpringSecurityUiService implements AclStrategy, ErrorsStrategy, Persistent
 		encodePassword = encode instanceof Boolean ? encode : false
 
 		forgotPasswordEmailFrom = conf.ui.forgotPassword.emailFrom ?: ''
-		forgotPasswordEmailSubject = conf.ui.forgotPassword.emailSubject ?: ''
 
 		registerDefaultRoleNames = conf.ui.register.defaultRoleNames ?: []
 

--- a/plugin/grails-app/views/layouts/email.gsp
+++ b/plugin/grails-app/views/layouts/email.gsp
@@ -1,0 +1,13 @@
+<%@ page contentType="text/html" %>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+
+<body>
+${raw(content)}
+</body>
+
+</html>

--- a/plugin/grails-app/views/register/_forgotPasswordMail.gsp
+++ b/plugin/grails-app/views/register/_forgotPasswordMail.gsp
@@ -1,0 +1,7 @@
+<g:message code="spring.security.ui.forgotPassword.email.greeting" args="${[username]}"/>,<br/>
+<br/>
+<g:message code="spring.security.ui.forgotPassword.email.line1"/><br/>
+<br/>
+<g:message code="spring.security.ui.forgotPassword.email.line2"/><br/>
+<br/>
+<g:message code="spring.security.ui.forgotPassword.email.line3"/> <a href="${url}"><g:message code="spring.security.ui.forgotPassword.email.here"/></a> <g:message code="spring.security.ui.forgotPassword.email.line4"/>

--- a/plugin/grails-app/views/register/_verifyRegistrationMail.gsp
+++ b/plugin/grails-app/views/register/_verifyRegistrationMail.gsp
@@ -1,0 +1,5 @@
+<g:message code="spring.security.ui.register.email.greeting" args="${[username]}"/>,<br/>
+<br/>
+<g:message code="spring.security.ui.register.email.line1"/><br/>
+<br/>
+<g:message code="spring.security.ui.register.email.line2"/> <a href="${url}"><g:message code="spring.security.ui.register.email.here"/></a> <g:message code="spring.security.ui.register.email.line3"/>

--- a/plugin/src/main/scripts/s2ui-override.groovy
+++ b/plugin/src/main/scripts/s2ui-override.groovy
@@ -129,6 +129,8 @@ switch ( directoryName ) {
 		copy template('views/register/forgotPassword.gsp'), new File(viewsDir, 'register')
 		copy template('views/register/register.gsp'), new File(viewsDir, 'register')
 		copy template('views/register/resetPassword.gsp'), new File(viewsDir, 'register')
+		copy template('views/register/_forgotPasswordMail.gsp'), new File(viewsDir, 'register')
+		copy template('views/register/_verifyRegistrationMail.gsp'), new File(viewsDir, 'register')
 		break
 	case 'registrationCode':
 		copy template('views/registrationCode/search.gsp'), new File(viewsDir, 'registrationCode')
@@ -164,6 +166,7 @@ switch ( directoryName ) {
 
 if ('register' == type) {
 	copy template('views/layouts/register.gsp'), file('grails-app/views/layouts/')
+	copy template('views/layouts/email.gsp'), file('grails-app/views/layouts/')
 }
 
 private void copy(pathOrResource, File destinationDirectory) {

--- a/plugin/src/test/groovy/grails/plugin/springsecurity/ui/RegisterControllerSpec.groovy
+++ b/plugin/src/test/groovy/grails/plugin/springsecurity/ui/RegisterControllerSpec.groovy
@@ -10,13 +10,14 @@ class RegisterControllerSpec extends Specification implements ControllerUnitTest
 
 	void setup() {
 		SpringSecurityUtils.setSecurityConfig [:] as ConfigObject
+		messageSource.addMessage 'spring.security.ui.register.email.subject', Locale.US, 'Registration Subject'
+		controller.messageSource = messageSource
 		updateFromConfig()
 	}
 
 	void cleanup() {
 		SpringSecurityUtils.resetSecurityConfig()
 	}
-
 	void 'passwordValidator validation fails if the password is the same as the username'() {
 		expect:
 		'command.password.error.username' == RegisterController.passwordValidator('username', [username: 'username'])
@@ -129,7 +130,7 @@ class RegisterControllerSpec extends Specification implements ControllerUnitTest
     void "verify generateLink for ('#action', #linkParams, '#shouldUseServerUrl') is #expectedUrl"() {
         given: "the grails.serverUrl is set"
         if (isConfigured) {
-            config.grails.serverURL = 'http://grails.org'
+			controller.serverURL = 'http://grails.org'
         }
 
         when: "the generateLink method is called"

--- a/plugin/src/test/groovy/grails/plugin/springsecurity/ui/SpringSecurityUiServiceSpec.groovy
+++ b/plugin/src/test/groovy/grails/plugin/springsecurity/ui/SpringSecurityUiServiceSpec.groovy
@@ -1,0 +1,51 @@
+package grails.plugin.springsecurity.ui
+
+import grails.plugin.springsecurity.SpringSecurityUtils
+import grails.plugin.springsecurity.ui.strategy.DefaultPropertiesStrategy
+import grails.testing.services.ServiceUnitTest
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class SpringSecurityUiServiceSpec extends Specification implements ServiceUnitTest<SpringSecurityUiService> {
+
+    void cleanup() {
+        SpringSecurityUtils.resetSecurityConfig()
+    }
+
+    void "forgot password email subject is loaded from config if config exists"() {
+        given: "the subject text exists in messages.properties"
+        addForgotPasswordEmailSubjectToMessageSource()
+
+        and: "the legacy config file exists"
+        if (hasConfig) {
+            SpringSecurityUtils.securityConfig.ui.forgotPassword.emailSubject = 'This is from the config'
+        }
+
+        and: "the properties strategy is set"
+        service.uiPropertiesStrategy = new DefaultPropertiesStrategy(springSecurityUiService: service)
+
+        and: "the service is initialized"
+        updateFromConfig()
+
+        when: "the value of forgotPasswordEmailSubject is requested"
+        String results = service.forgotPasswordEmailSubject
+
+        then: "the value from config is used if it exists, else the value from messages.properties is used"
+        results == expectedResults
+
+        where:
+        hasConfig | expectedResults
+        true      | 'This is from the config'
+        false     | 'Password Reset'
+    }
+
+    private void updateFromConfig() {
+        service.messageSource = messageSource
+        service.initialize()
+    }
+
+    protected void addForgotPasswordEmailSubjectToMessageSource() {
+        messageSource.addMessage 'spring.security.ui.forgotPassword.email.subject', Locale.US, 'Password Reset'
+    }
+}

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -19,7 +19,7 @@ fi
 
 ./gradlew install --stacktrace || EXIT_STATUS=$?
 if [[ $EXIT_STATUS -ne 0 ]]; then
-    echo "Check failed"
+    echo "install failed"
     exit $EXIT_STATUS
 fi
 

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -95,4 +95,4 @@ if [[ -n $TRAVIS_TAG ]] || [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST
   rm -rf gh-pages
 fi
 
-exit 0
+exit $EXIT_STATUS


### PR DESCRIPTION
    • Modified forgot password email to be internationalized by now rendering it with a gsp that utilizes `messages.properties`
    • modified email from config text to be more friendly.  It is now 'Do Not Reply <do.not.reply@localhost>'
    • modified subject line retrieval to pass an array to `getMessage` instead of a List
    • fixed bug where html was being escaped in email body
    • sending of verification email using gsps has been implemented
    • for backwards compatibility, if the user has overridden the body in the config, the text from the config will be used in registration email
    • modified forgot password email logic to support using the email body as defined in the config it it exists, otherwise it will use gsps
    • fixed broken tests
    • added a test that verifies the registration email subject will be loaded first from `DefaultUiSecurityConfig` and, if it doesn't exist in config, then it will be loaded from `messages.properties`.
    • implemented loading of forgot password email subject from config if it exists (for legacy support) else it will load from `messages.properties`
    • wrote a test

This will resolve issue #43 
