### PR TITLE
issue 96: auth.gsp does not support grails.plugin.springsecurity.ui.gsp.layoutUi config setting

### DIFF
--- a/plugin/grails-app/views/login/auth.gsp
+++ b/plugin/grails-app/views/login/auth.gsp
@@ -1,7 +1,7 @@
 <g:set var='securityConfig' value='${applicationContext.springSecurityService.securityConfig}'/>
 <html>
 <head>
-	<meta name="layout" content="main"/>
+	<meta name="layout" content="${layoutUi}"/>
 	<s2ui:title messageCode='spring.security.ui.login.title'/>
 	<asset:stylesheet src='spring-security-ui-auth.css'/>
 </head>


### PR DESCRIPTION
The `auth.gsp` page does not currently support the `grails.plugin.springsecurity.ui.gsp.layoutUi` config setting as described in section 10.3.3 of the documentation at https://grails-plugins.github.io/grails-spring-security-ui/v3/index.html#application-groovy-attributes

It should.

This issue was inspired by the PR at https://github.com/grails-plugins/grails-spring-security-ui/pull/67

This PR is a fix for issue https://github.com/grails-plugins/grails-spring-security-ui/issues/96