### PR TITLE
add autofocus + required html attrs to username input in login form

### DIFF
--- a/plugin/grails-app/views/login/auth.gsp
+++ b/plugin/grails-app/views/login/auth.gsp
@@ -15,7 +15,7 @@
 				<table>
 					<tr>
 						<td><label for="username"><g:message code='spring.security.ui.login.username'/></label></td>
-						<td><input type="text" name="${securityConfig.apf.usernameParameter}" id="username" class='formLogin' size="20"/></td>
+						<td><input type="text" name="${securityConfig.apf.usernameParameter}" id="username" class='formLogin' size="20" autocapitalize="off" autofocus required/></td>
 					</tr>
 					<tr>
 						<td><label for="password"><g:message code='spring.security.ui.login.password'/></label></td>


### PR DESCRIPTION
mild attempt to improve UX of login form

autocapitalize is for mobile only. 

I'd be glad to implement similar password show/hide feature that was recently merged on security core, but would want to use svgs in assets rather than unicode for the icons since it is a bit more polished form.