### PR TITLE
refactor: explicitly specify username property in search method

### DIFF
--- a/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/UserController.groovy
+++ b/plugin/grails-app/controllers/grails/plugin/springsecurity/ui/UserController.groovy
@@ -68,7 +68,7 @@ class UserController extends AbstractS2UiDomainController {
 		}
 
 		def results = doSearch { ->
-			like 'username', delegate
+			like 'username','username', delegate
 			eqBoolean 'accountExpired', delegate
 			eqBoolean 'accountLocked', delegate
 			eqBoolean 'enabled', delegate


### PR DESCRIPTION
What the Change Does
🔧 Additional Parameter: We are now explicitly specifying the propertyName as 'username' instead of leaving it null.

In the like method, if propertyName is null, it is set as the result of toPropertyName(paramName). By explicitly providing 'username', we ensure that the propertyName used in the search is exactly 'username'.

✨ Clarity Improvement: This change is useful if paramName and propertyName can be different in some context, but in this specific case, we are only making explicit what was already being done implicitly.

Impact of the Change
📝 Clarity: It makes it more explicit that the username field is both the parameter name and the property name to search.
⚙️ Functionality: This should not change functionality in this specific case because toPropertyName('username') was likely already returning 'username'.